### PR TITLE
Move Gemini analysis behind backend API

### DIFF
--- a/src/server/controllers/geminiController.ts
+++ b/src/server/controllers/geminiController.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from "express";
+import { analyzeTaskWithGemini } from "../services/geminiService.js";
+
+export const analyzeTask = async (req: Request, res: Response) => {
+  try {
+    const { input, categories } = req.body;
+
+    if (typeof input !== "string" || input.trim().length === 0) {
+      return res.status(400).json({ error: "Task input is required" });
+    }
+
+    const trimmedInput = input.trim();
+    if (trimmedInput.length > 500) {
+      return res.status(400).json({ error: "Task input must be 500 characters or fewer" });
+    }
+
+    if (!Array.isArray(categories) || categories.some((category) => typeof category !== "string")) {
+      return res.status(400).json({ error: "Categories must be an array of strings" });
+    }
+
+    const normalizedCategories = categories.map((category) => category.trim()).filter(Boolean);
+    if (normalizedCategories.length === 0 || normalizedCategories.length > 50) {
+      return res.status(400).json({ error: "Provide between 1 and 50 categories" });
+    }
+
+    if (normalizedCategories.some((category) => category.length > 100)) {
+      return res.status(400).json({ error: "Category names must be 100 characters or fewer" });
+    }
+
+    const result = await analyzeTaskWithGemini(trimmedInput, normalizedCategories);
+    res.status(200).json(result);
+  } catch (error: any) {
+    console.error("Error analyzing task:", error);
+    res.status(500).json({ error: error.message || "Failed to analyze task" });
+  }
+};

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -10,6 +10,7 @@ import {
   createSharedTask,
   getFamilyTasks,
 } from "../controllers/taskController.js";
+import { analyzeTask } from "../controllers/geminiController.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 const router = Router();
@@ -24,6 +25,7 @@ router.post("/family/invite", authMiddleware, generateInvite);
 router.post("/family/join", authMiddleware, joinFamily);
 
 // Task routes
+router.post("/analyze-task", authMiddleware, analyzeTask);
 router.post("/tasks/shared", authMiddleware, createSharedTask);
 router.get("/tasks/family/:familyId", authMiddleware, getFamilyTasks);
 

--- a/src/server/services/geminiService.ts
+++ b/src/server/services/geminiService.ts
@@ -1,0 +1,102 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import type { AIAnalysisResult } from "../../shared/geminiTypes.js";
+
+const getGeminiClient = () => {
+  const apiKey = process.env.GEMINI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error("GEMINI_API_KEY is not configured");
+  }
+
+  return new GoogleGenAI({ apiKey });
+};
+
+export async function analyzeTaskWithGemini(
+  input: string,
+  categories: string[]
+): Promise<AIAnalysisResult> {
+  const model = "gemini-3-flash-preview";
+  const now = new Date();
+  const todayStr = now.toISOString().split("T")[0];
+
+  const prompt = `
+    Analyze the following task or thought and categorize it into one of the provided categories.
+    Also, assign a priority from 1 (Low) to 5 (High) based on its urgency and importance.
+
+    CRITICAL:
+    1. Extract any mentioned date and time.
+    2. Detect if this is a shopping list or grocery-related request (e.g., "buy milk", "need eggs", "shopping list").
+    3. If it is a shopping list:
+       - Set isShoppingList to true.
+       - Extract specific items (e.g., "milk", "eggs", "detergent").
+       - Categorize each item into groups like "신선식품" (Fresh), "공산품" (General), "생활용품" (Household), etc.
+       - Set checked to false for all items.
+
+    - Today's date is ${todayStr}.
+    - Task/Thought: "${input}"
+    - Available Categories: ${categories.join(", ")}
+
+    Provide a brief reasoning for your choice.
+  `;
+
+  const ai = getGeminiClient();
+  const response = await ai.models.generateContent({
+    model,
+    contents: prompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          categoryName: {
+            type: Type.STRING,
+            description: "The name of the category that best fits the task.",
+          },
+          priority: {
+            type: Type.NUMBER,
+            description: "A priority score from 1 to 5.",
+          },
+          reasoning: {
+            type: Type.STRING,
+            description: "A brief explanation of why this category and priority were chosen.",
+          },
+          dueDate: {
+            type: Type.STRING,
+            description: "Extracted date in YYYY-MM-DD format, or null.",
+            nullable: true,
+          },
+          reminderTime: {
+            type: Type.STRING,
+            description: "Extracted time in HH:mm format, or null.",
+            nullable: true,
+          },
+          isShoppingList: {
+            type: Type.BOOLEAN,
+            description: "Whether the input is a shopping list.",
+          },
+          shoppingItems: {
+            type: Type.ARRAY,
+            items: {
+              type: Type.OBJECT,
+              properties: {
+                name: { type: Type.STRING },
+                category: { type: Type.STRING },
+                checked: { type: Type.BOOLEAN },
+              },
+              required: ["name", "category", "checked"],
+            },
+            nullable: true,
+          },
+        },
+        required: ["categoryName", "priority", "reasoning", "isShoppingList"],
+      },
+    },
+  });
+
+  try {
+    return JSON.parse(response.text || "{}") as AIAnalysisResult;
+  } catch (error) {
+    console.error("Failed to parse AI response:", error);
+    throw new Error("AI analysis failed to return valid JSON.");
+  }
+}

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,109 +1,29 @@
-import { GoogleGenAI, Type } from "@google/genai";
+import { auth } from "../firebase.js";
+import type { AIAnalysisResult, ShoppingItem } from "../shared/geminiTypes.js";
 
-const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || "" });
-
-export interface ShoppingItem {
-  name: string;
-  category: string;
-  checked: boolean;
-}
-
-export interface AIAnalysisResult {
-  categoryName: string;
-  priority: number;
-  reasoning: string;
-  dueDate?: string; // YYYY-MM-DD
-  reminderTime?: string; // HH:mm
-  isShoppingList: boolean;
-  shoppingItems?: ShoppingItem[];
-}
+export type { AIAnalysisResult, ShoppingItem };
 
 export async function analyzeTask(
   input: string,
   categories: string[]
 ): Promise<AIAnalysisResult> {
-  const model = "gemini-3-flash-preview";
-  const now = new Date();
-  const todayStr = now.toISOString().split('T')[0];
-  
-  const prompt = `
-    Analyze the following task or thought and categorize it into one of the provided categories.
-    Also, assign a priority from 1 (Low) to 5 (High) based on its urgency and importance.
-    
-    CRITICAL: 
-    1. Extract any mentioned date and time.
-    2. Detect if this is a shopping list or grocery-related request (e.g., "buy milk", "need eggs", "shopping list").
-    3. If it is a shopping list:
-       - Set isShoppingList to true.
-       - Extract specific items (e.g., "milk", "eggs", "detergent").
-       - Categorize each item into groups like "신선식품" (Fresh), "공산품" (General), "생활용품" (Household), etc.
-       - Set checked to false for all items.
-    
-    - Today's date is ${todayStr}.
-    - Task/Thought: "${input}"
-    - Available Categories: ${categories.join(", ")}
+  const user = auth.currentUser;
+  if (!user) throw new Error("User not authenticated");
 
-    Provide a brief reasoning for your choice.
-  `;
-
-  const response = await ai.models.generateContent({
-    model,
-    contents: prompt,
-    config: {
-      responseMimeType: "application/json",
-      responseSchema: {
-        type: Type.OBJECT,
-        properties: {
-          categoryName: {
-            type: Type.STRING,
-            description: "The name of the category that best fits the task.",
-          },
-          priority: {
-            type: Type.NUMBER,
-            description: "A priority score from 1 to 5.",
-          },
-          reasoning: {
-            type: Type.STRING,
-            description: "A brief explanation of why this category and priority were chosen.",
-          },
-          dueDate: {
-            type: Type.STRING,
-            description: "Extracted date in YYYY-MM-DD format, or null.",
-            nullable: true,
-          },
-          reminderTime: {
-            type: Type.STRING,
-            description: "Extracted time in HH:mm format, or null.",
-            nullable: true,
-          },
-          isShoppingList: {
-            type: Type.BOOLEAN,
-            description: "Whether the input is a shopping list.",
-          },
-          shoppingItems: {
-            type: Type.ARRAY,
-            items: {
-              type: Type.OBJECT,
-              properties: {
-                name: { type: Type.STRING },
-                category: { type: Type.STRING },
-                checked: { type: Type.BOOLEAN },
-              },
-              required: ["name", "category", "checked"],
-            },
-            nullable: true,
-          },
-        },
-        required: ["categoryName", "priority", "reasoning", "isShoppingList"],
-      },
+  const token = await user.getIdToken();
+  const response = await fetch("/api/analyze-task", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
     },
+    body: JSON.stringify({ input, categories }),
   });
 
-  try {
-    const result = JSON.parse(response.text || "{}") as AIAnalysisResult;
-    return result;
-  } catch (error) {
-    console.error("Failed to parse AI response:", error);
-    throw new Error("AI analysis failed to return valid JSON.");
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "AI analysis failed");
   }
+
+  return response.json();
 }

--- a/src/shared/geminiTypes.ts
+++ b/src/shared/geminiTypes.ts
@@ -1,0 +1,15 @@
+export interface ShoppingItem {
+  name: string;
+  category: string;
+  checked: boolean;
+}
+
+export interface AIAnalysisResult {
+  categoryName: string;
+  priority: number;
+  reasoning: string;
+  dueDate?: string;
+  reminderTime?: string;
+  isShoppingList: boolean;
+  shoppingItems?: ShoppingItem[];
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,11 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import {defineConfig, loadEnv} from 'vite';
+import {defineConfig} from 'vite';
 
-export default defineConfig(({mode}) => {
-  const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
   return {
     plugins: [react(), tailwindcss()],
-    define: {
-      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary

- Move Gemini task analysis from the browser bundle to an authenticated Express API route.
- Keep the frontend `analyzeTask` API as a client wrapper that calls `/api/analyze-task`.
- Share Gemini result types between client and server.
- Remove the Vite `process.env.GEMINI_API_KEY` client-side define.

## Issue

Refs #2

## Verification

- `npm run lint`
- `npm run build`
- `npm audit --audit-level=low`
- `curl http://localhost:5001/health`
- `POST /api/analyze-task` without auth returns 401

## Notes

Firebase Web config still appears in the browser bundle as expected. Gemini key usage is now server-side only.