### PR TITLE
Document Firebase Admin credential setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,9 @@ APP_URL="MY_APP_URL"
 # PORT: Local server port. Defaults to 5001 when unset.
 PORT=5001
 
-# FIREBASE_SERVICE_ACCOUNT: Required for Firebase Admin SDK to verify ID tokens.
-# Can be a JSON string or a path to a service account JSON file.
+# FIREBASE_SERVICE_ACCOUNT: Optional for Firebase Admin SDK.
+# Locally, this can be a service account JSON string or a path to a service account JSON file.
+# In production on Google Cloud, prefer Application Default Credentials from the runtime service account.
 FIREBASE_SERVICE_ACCOUNT=
 FIREBASE_PROJECT_ID="MY_FIREBASE_PROJECT_ID"
 FIREBASE_FIRESTORE_DATABASE_ID="MY_FIRESTORE_DATABASE_ID"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,32 @@ Deploy Firestore rules:
 firebase deploy --only firestore:rules --project ai-task-organizer-3de8d
 ```
 
+## Firebase Admin Credentials
+
+The backend uses Firebase Admin SDK to verify ID tokens and access Firestore for server routes.
+
+Set these backend environment variables:
+
+```bash
+FIREBASE_PROJECT_ID="MY_FIREBASE_PROJECT_ID"
+FIREBASE_FIRESTORE_DATABASE_ID="MY_FIRESTORE_DATABASE_ID"
+```
+
+For local development, choose one credential mode:
+
+```bash
+# Option 1: use Application Default Credentials
+gcloud auth application-default login
+
+# Option 2: point to a local service account file
+FIREBASE_SERVICE_ACCOUNT="/absolute/path/to/service-account.json"
+
+# Option 3: provide the service account JSON string
+FIREBASE_SERVICE_ACCOUNT='{"type":"service_account",...}'
+```
+
+For production on Google Cloud, prefer Application Default Credentials from the runtime service account instead of storing service account JSON in an environment variable. The runtime service account needs permission to verify Firebase Auth tokens and read/write the configured Firestore database.
+
 ## Firebase Auth
 
 For local Google sign-in, add `localhost` to Firebase Console > Authentication > Settings > Authorized domains.

--- a/src/server/firebaseAdmin.ts
+++ b/src/server/firebaseAdmin.ts
@@ -2,12 +2,17 @@ import { initializeApp, getApps, getApp, cert } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
 import dotenv from "dotenv";
+import fs from "fs";
 
 dotenv.config({ path: ".env" });
 dotenv.config({ path: ".env.local", override: true });
 
 const projectId = process.env.FIREBASE_PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT;
 const dbId = process.env.FIREBASE_FIRESTORE_DATABASE_ID || process.env.VITE_FIREBASE_FIRESTORE_DATABASE_ID || "(default)";
+
+if (!projectId) {
+  console.warn("[FirebaseAdmin] FIREBASE_PROJECT_ID or GOOGLE_CLOUD_PROJECT should be set explicitly.");
+}
 
 if (projectId) {
   process.env.GOOGLE_CLOUD_PROJECT = projectId;
@@ -32,23 +37,29 @@ if (!getApps().length) {
       console.log("[FirebaseAdmin] Initialized with Service Account JSON");
     } catch (e) {
       console.error("[FirebaseAdmin] Failed to parse FIREBASE_SERVICE_ACCOUNT as JSON:", e);
+      throw e;
     }
   } 
   
   if (!app && serviceAccount && !serviceAccount.startsWith('{')) {
+    if (!fs.existsSync(serviceAccount)) {
+      throw new Error("FIREBASE_SERVICE_ACCOUNT file path does not exist");
+    }
+
     try {
       app = initializeApp({
         credential: cert(serviceAccount),
         projectId: projectId,
       });
-      console.log(`[FirebaseAdmin] Initialized with Service Account File: ${serviceAccount}`);
+      console.log("[FirebaseAdmin] Initialized with Service Account File");
     } catch (e) {
       console.error("[FirebaseAdmin] Failed to initialize with SA file:", e);
+      throw e;
     }
   }
 
   if (!app) {
-    console.log("[FirebaseAdmin] Initializing with Application Default Credentials (ADC)");
+    console.log("[FirebaseAdmin] Initializing with Application Default Credentials");
     app = initializeApp({
       projectId: projectId,
     });


### PR DESCRIPTION
## Summary

- Document Firebase Admin credential modes for local and production environments.
- Clarify that production on Google Cloud should prefer runtime Application Default Credentials.
- Add backend Firebase project/database env vars to the credential section.
- Harden Firebase Admin initialization by failing fast on invalid service account JSON or missing service account file paths.
- Avoid logging the service account file path.

## Issue

Refs #2

## Verification

- `npm run lint`
- `npm run build`
- `npm audit --audit-level=low`
- Restarted local server and confirmed Firebase Admin initializes with Application Default Credentials against `ai-task-organizer-3de8d` / `task-organizer-main`.
- `curl http://localhost:5001/health` returns 200.