### PR TITLE
Move task creation behind backend API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,8 @@ import {
   or
 } from 'firebase/firestore';
 import { auth, db } from './firebase';
-import { analyzeTask, AIAnalysisResult, ShoppingItem } from './services/geminiService';
+import type { ShoppingItem } from './services/geminiService';
+import { analyzeAndCreateTask } from './services/taskService';
 import { useNotification } from './hooks/useNotification';
 import { FamilyProvider, useFamily } from './contexts/FamilyContext';
 import { FamilySettings } from './components/FamilySettings';
@@ -129,6 +130,13 @@ function AppContent() {
 
   const { families } = useFamily();
   const { permission, requestPermission, sendNotification } = useNotification();
+  const availableCategoriesForNewTask = useMemo(
+    () =>
+      categories.filter(category =>
+        selectedFamilyId ? category.familyId === selectedFamilyId : !category.familyId
+      ),
+    [categories, selectedFamilyId]
+  );
 
   // Notification Scheduler
   useEffect(() => {
@@ -270,34 +278,23 @@ function AppContent() {
 
   const processNewTask = async () => {
     if (!user || !newTaskInput.trim()) return;
-    if (categories.length === 0) {
-      toast.error("먼저 카테고리를 하나 이상 만들어주세요.");
+    if (availableCategoriesForNewTask.length === 0) {
+      toast.error(
+        selectedFamilyId
+          ? "이 가족 그룹에 카테고리를 하나 이상 만들어주세요."
+          : "먼저 개인 카테고리를 하나 이상 만들어주세요."
+      );
       return;
     }
 
     setIsAnalyzing(true);
     try {
-      const categoryNames = categories.map(c => c.name);
-      const analysis = await analyzeTask(newTaskInput, categoryNames);
-      
-      const category = categories.find(c => c.name === analysis.categoryName) || categories[0];
-
-      await addDoc(collection(db, 'tasks'), {
-        title: newTaskInput.trim(),
-        categoryId: category.id,
+      const createdTask = await analyzeAndCreateTask({
+        input: newTaskInput,
         familyId: selectedFamilyId || null,
-        priority: analysis.priority,
-        status: 'pending',
-        aiReasoning: analysis.reasoning,
-        dueDate: analysis.dueDate || null,
-        reminderTime: analysis.reminderTime || null,
-        isShoppingList: analysis.isShoppingList || false,
-        shoppingItems: analysis.shoppingItems || [],
-        userId: user.uid,
-        createdAt: serverTimestamp()
       });
 
-      if (analysis.isShoppingList) {
+      if (createdTask.isShoppingList) {
         setActiveTab('shopping');
       }
 
@@ -305,7 +302,8 @@ function AppContent() {
       toast.success("할 일이 추가되었습니다!");
     } catch (error) {
       console.error("Process task error:", error);
-      toast.error("AI 분석 중 오류가 발생했습니다.");
+      const message = error instanceof Error ? error.message : "할 일 추가 중 오류가 발생했습니다.";
+      toast.error(message);
     } finally {
       setIsAnalyzing(false);
     }

--- a/src/server/controllers/taskController.ts
+++ b/src/server/controllers/taskController.ts
@@ -1,6 +1,33 @@
 import { Request, Response } from "express";
 import * as taskService from "../services/taskService.js";
 
+export const analyzeAndCreateTask = async (req: Request, res: Response) => {
+  try {
+    const { input, familyId } = req.body;
+    // @ts-ignore
+    const user = req.user;
+
+    if (typeof input !== "string" || input.trim().length === 0) {
+      return res.status(400).json({ error: "Task input is required" });
+    }
+
+    if (familyId !== undefined && familyId !== null && typeof familyId !== "string") {
+      return res.status(400).json({ error: "Family ID must be a string" });
+    }
+
+    const task = await taskService.analyzeAndCreateTask({
+      input,
+      familyId: familyId ?? null,
+      userId: user.uid,
+    });
+
+    res.status(201).json(task);
+  } catch (error: any) {
+    console.error("Error analyzing and creating task:", error);
+    res.status(400).json({ error: error.message || "Failed to create task" });
+  }
+};
+
 export const createSharedTask = async (req: Request, res: Response) => {
   try {
     // @ts-ignore

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -7,6 +7,7 @@ import {
   getMyFamilies,
 } from "../controllers/familyController.js";
 import {
+  analyzeAndCreateTask,
   createSharedTask,
   getFamilyTasks,
 } from "../controllers/taskController.js";
@@ -26,6 +27,7 @@ router.post("/family/join", authMiddleware, joinFamily);
 
 // Task routes
 router.post("/analyze-task", authMiddleware, analyzeTask);
+router.post("/tasks/analyze-and-create", authMiddleware, analyzeAndCreateTask);
 router.post("/tasks/shared", authMiddleware, createSharedTask);
 router.get("/tasks/family/:familyId", authMiddleware, getFamilyTasks);
 

--- a/src/server/services/taskService.ts
+++ b/src/server/services/taskService.ts
@@ -1,4 +1,8 @@
+import { Timestamp } from "firebase-admin/firestore";
+import type { AIAnalysisResult } from "../../shared/geminiTypes.js";
+import type { TaskRecord } from "../../shared/taskTypes.js";
 import { adminDb } from "../firebaseAdmin.js";
+import { analyzeTaskWithGemini } from "./geminiService.js";
 import { handleFirestoreError } from "../utils/errorHandlers.js";
 
 export interface CreateTaskParams {
@@ -15,6 +19,113 @@ export interface CreateTaskParams {
   shoppingItems?: Array<{ name: string; category: string; checked: boolean }>;
   userId: string;
 }
+
+interface AnalyzeAndCreateTaskParams {
+  input: string;
+  familyId?: string | null;
+  userId: string;
+}
+
+interface CategoryRecord {
+  id: string;
+  name: string;
+  userId: string;
+  familyId?: string | null;
+}
+
+const ensureFamilyMembership = async (familyId: string, userId: string) => {
+  const familyDoc = await adminDb.collection("familyGroups").doc(familyId).get();
+  if (!familyDoc.exists) {
+    throw new Error("Family group not found");
+  }
+
+  const familyData = familyDoc.data();
+  if (!familyData?.members.includes(userId)) {
+    throw new Error("User is not a member of this family group");
+  }
+};
+
+const getCategoriesForScope = async (
+  userId: string,
+  familyId?: string | null
+): Promise<CategoryRecord[]> => {
+  const query = familyId
+    ? adminDb.collection("categories").where("familyId", "==", familyId)
+    : adminDb.collection("categories").where("userId", "==", userId).where("familyId", "==", null);
+
+  const snapshot = await query.orderBy("createdAt", "desc").get();
+
+  return snapshot.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      name: String(data.name || ""),
+      userId: String(data.userId || ""),
+      familyId: data.familyId ?? null,
+    };
+  });
+};
+
+const selectCategory = (analysis: AIAnalysisResult, categories: CategoryRecord[]) => {
+  const normalizedName = analysis.categoryName.trim().toLowerCase();
+  return (
+    categories.find((category) => category.name.trim().toLowerCase() === normalizedName) ||
+    categories[0]
+  );
+};
+
+export const analyzeAndCreateTask = async (
+  params: AnalyzeAndCreateTaskParams
+): Promise<TaskRecord> => {
+  const title = params.input.trim();
+
+  if (!title) {
+    throw new Error("Task input is required");
+  }
+
+  if (title.length > 500) {
+    throw new Error("Task input must be 500 characters or fewer");
+  }
+
+  if (params.familyId && typeof params.familyId !== "string") {
+    throw new Error("Family ID must be a string");
+  }
+
+  if (params.familyId) {
+    await ensureFamilyMembership(params.familyId, params.userId);
+  }
+
+  const categories = await getCategoriesForScope(params.userId, params.familyId);
+  if (categories.length === 0) {
+    throw new Error("Create at least one category before adding tasks");
+  }
+
+  const analysis = await analyzeTaskWithGemini(
+    title,
+    categories.map((category) => category.name)
+  );
+
+  const category = selectCategory(analysis, categories);
+  const taskRef = adminDb.collection("tasks").doc();
+  const taskData: TaskRecord = {
+    id: taskRef.id,
+    title,
+    categoryId: category.id,
+    familyId: params.familyId ?? null,
+    priority: analysis.priority,
+    status: "pending",
+    aiReasoning: analysis.reasoning,
+    dueDate: analysis.dueDate ?? null,
+    reminderTime: analysis.reminderTime ?? null,
+    isShoppingList: analysis.isShoppingList || false,
+    shoppingItems: analysis.shoppingItems || [],
+    userId: params.userId,
+    createdAt: Timestamp.now(),
+  };
+
+  await taskRef.set(taskData);
+  return taskData;
+};
 
 export const createSharedTask = async (params: CreateTaskParams) => {
   // 1. Basic Validation
@@ -46,14 +157,7 @@ export const createSharedTask = async (params: CreateTaskParams) => {
 
   // 4. Family Membership Validation (if familyId is provided)
   if (params.familyId) {
-    const familyDoc = await adminDb.collection("familyGroups").doc(params.familyId).get();
-    if (!familyDoc.exists) {
-      throw new Error("Family group not found");
-    }
-    const familyData = familyDoc.data();
-    if (!familyData?.members.includes(params.userId)) {
-      throw new Error("User is not a member of this family group");
-    }
+    await ensureFamilyMembership(params.familyId, params.userId);
   }
 
   // 5. Create Task
@@ -61,7 +165,7 @@ export const createSharedTask = async (params: CreateTaskParams) => {
   const taskData = {
     ...params,
     id: taskRef.id,
-    createdAt: new Date().toISOString(),
+    createdAt: Timestamp.now(),
   };
 
   await taskRef.set(taskData);

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -1,0 +1,33 @@
+import { auth } from "../firebase.js";
+import type {
+  AnalyzeAndCreateTaskRequest,
+  AnalyzeAndCreateTaskResponse,
+} from "../shared/taskTypes.js";
+
+export type { AnalyzeAndCreateTaskRequest, AnalyzeAndCreateTaskResponse };
+
+export async function analyzeAndCreateTask(
+  payload: AnalyzeAndCreateTaskRequest
+): Promise<AnalyzeAndCreateTaskResponse> {
+  const user = auth.currentUser;
+  if (!user) {
+    throw new Error("User not authenticated");
+  }
+
+  const token = await user.getIdToken();
+  const response = await fetch("/api/tasks/analyze-and-create", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to create task");
+  }
+
+  return response.json();
+}

--- a/src/shared/taskTypes.ts
+++ b/src/shared/taskTypes.ts
@@ -1,0 +1,25 @@
+import type { ShoppingItem } from "./geminiTypes.js";
+
+export interface TaskRecord {
+  id: string;
+  title: string;
+  description?: string;
+  categoryId: string;
+  familyId?: string | null;
+  priority: number;
+  status: "pending" | "completed";
+  aiReasoning?: string;
+  dueDate?: string | null;
+  reminderTime?: string | null;
+  isShoppingList?: boolean;
+  shoppingItems?: ShoppingItem[];
+  userId: string;
+  createdAt: unknown;
+}
+
+export interface AnalyzeAndCreateTaskRequest {
+  input: string;
+  familyId?: string | null;
+}
+
+export type AnalyzeAndCreateTaskResponse = TaskRecord;


### PR DESCRIPTION
Refs #2

## Summary
- add a backend endpoint that analyzes task text and creates the Firestore task in one flow
- move the frontend task creation path to call the new authenticated API
- keep task creation scoped to personal or selected family categories and use server timestamps

## Verification
- npm run lint
- npm run build
- curl http://localhost:5001/health
- curl -X POST http://localhost:5001/api/tasks/analyze-and-create without auth returns 401