### PR TITLE
Move task updates behind backend API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,7 @@ import {
   where, 
   onSnapshot, 
   deleteDoc, 
-  doc, 
-  updateDoc, 
+  doc,
   serverTimestamp, 
   orderBy,
   getDocs,
@@ -22,7 +21,11 @@ import {
 } from 'firebase/firestore';
 import { auth, db } from './firebase';
 import type { ShoppingItem } from './services/geminiService';
-import { analyzeAndCreateTask } from './services/taskService';
+import {
+  analyzeAndCreateTask,
+  deleteTask as deleteTaskOnServer,
+  updateTask as updateTaskOnServer,
+} from './services/taskService';
 import { useNotification } from './hooks/useNotification';
 import { FamilyProvider, useFamily } from './contexts/FamilyContext';
 import { FamilySettings } from './components/FamilySettings';
@@ -311,12 +314,13 @@ function AppContent() {
 
   const toggleTaskStatus = async (task: Task) => {
     try {
-      await updateDoc(doc(db, 'tasks', task.id), {
+      await updateTaskOnServer(task.id, {
         status: task.status === 'pending' ? 'completed' : 'pending'
       });
     } catch (error) {
       console.error("Toggle task error:", error);
-      toast.error("상태 변경에 실패했습니다.");
+      const message = error instanceof Error ? error.message : "상태 변경에 실패했습니다.";
+      toast.error(message);
     }
   };
 
@@ -328,22 +332,24 @@ function AppContent() {
     newItems[itemIndex] = { ...newItems[itemIndex], checked: !newItems[itemIndex].checked };
 
     try {
-      await updateDoc(doc(db, 'tasks', taskId), {
+      await updateTaskOnServer(taskId, {
         shoppingItems: newItems
       });
     } catch (error) {
       console.error("Toggle shopping item error:", error);
-      toast.error("품목 상태 변경에 실패했습니다.");
+      const message = error instanceof Error ? error.message : "품목 상태 변경에 실패했습니다.";
+      toast.error(message);
     }
   };
 
   const deleteTask = async (id: string) => {
     try {
-      await deleteDoc(doc(db, 'tasks', id));
+      await deleteTaskOnServer(id);
       toast.success("할 일이 삭제되었습니다.");
     } catch (error) {
       console.error("Delete task error:", error);
-      toast.error("삭제에 실패했습니다.");
+      const message = error instanceof Error ? error.message : "삭제에 실패했습니다.";
+      toast.error(message);
     }
   };
 

--- a/src/server/controllers/taskController.ts
+++ b/src/server/controllers/taskController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import type { UpdateTaskRequest } from "../../shared/taskTypes.js";
 import * as taskService from "../services/taskService.js";
 
 export const analyzeAndCreateTask = async (req: Request, res: Response) => {
@@ -39,6 +40,46 @@ export const createSharedTask = async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error("Error creating shared task:", error);
     res.status(400).json({ error: error.message || "Failed to create shared task" });
+  }
+};
+
+export const updateTask = async (req: Request, res: Response) => {
+  try {
+    const { taskId } = req.params;
+    const updates = req.body as UpdateTaskRequest;
+    // @ts-ignore
+    const user = req.user;
+
+    if (!taskId) {
+      return res.status(400).json({ error: "Task ID is required" });
+    }
+
+    const task = await taskService.updateTask(taskId, updates, user.uid);
+    res.status(200).json(task);
+  } catch (error: any) {
+    console.error("Error updating task:", error);
+    const statusCode = error.message === "Task not found" ? 404 : error.message === "Access denied" ? 403 : 400;
+    res.status(statusCode).json({ error: error.message || "Failed to update task" });
+  }
+};
+
+export const deleteTask = async (req: Request, res: Response) => {
+  try {
+    const { taskId } = req.params;
+    // @ts-ignore
+    const user = req.user;
+
+    if (!taskId) {
+      return res.status(400).json({ error: "Task ID is required" });
+    }
+
+    await taskService.deleteTask(taskId, user.uid);
+    res.status(204).send();
+  } catch (error: any) {
+    console.error("Error deleting task:", error);
+    const statusCode =
+      error.message === "Task not found" ? 404 : error.message === "Only the task owner can delete this task" ? 403 : 400;
+    res.status(statusCode).json({ error: error.message || "Failed to delete task" });
   }
 };
 

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -9,7 +9,9 @@ import {
 import {
   analyzeAndCreateTask,
   createSharedTask,
+  deleteTask,
   getFamilyTasks,
+  updateTask,
 } from "../controllers/taskController.js";
 import { analyzeTask } from "../controllers/geminiController.js";
 import { authMiddleware } from "../middleware/auth.js";
@@ -29,6 +31,8 @@ router.post("/family/join", authMiddleware, joinFamily);
 router.post("/analyze-task", authMiddleware, analyzeTask);
 router.post("/tasks/analyze-and-create", authMiddleware, analyzeAndCreateTask);
 router.post("/tasks/shared", authMiddleware, createSharedTask);
+router.patch("/tasks/:taskId", authMiddleware, updateTask);
+router.delete("/tasks/:taskId", authMiddleware, deleteTask);
 router.get("/tasks/family/:familyId", authMiddleware, getFamilyTasks);
 
 export default router;

--- a/src/server/services/taskService.ts
+++ b/src/server/services/taskService.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from "firebase-admin/firestore";
 import type { AIAnalysisResult } from "../../shared/geminiTypes.js";
-import type { TaskRecord } from "../../shared/taskTypes.js";
+import type { TaskRecord, UpdateTaskRequest } from "../../shared/taskTypes.js";
 import { adminDb } from "../firebaseAdmin.js";
 import { analyzeTaskWithGemini } from "./geminiService.js";
 import { handleFirestoreError } from "../utils/errorHandlers.js";
@@ -32,6 +32,64 @@ interface CategoryRecord {
   userId: string;
   familyId?: string | null;
 }
+
+const getTaskById = async (taskId: string) => {
+  const taskDoc = await adminDb.collection("tasks").doc(taskId).get();
+  if (!taskDoc.exists) {
+    throw new Error("Task not found");
+  }
+
+  return {
+    id: taskDoc.id,
+    ...(taskDoc.data() as Omit<TaskRecord, "id">),
+  } as TaskRecord;
+};
+
+const canUpdateTask = async (task: TaskRecord, userId: string) => {
+  if (task.userId === userId) {
+    return true;
+  }
+
+  if (task.familyId) {
+    await ensureFamilyMembership(task.familyId, userId);
+    return true;
+  }
+
+  return false;
+};
+
+const canDeleteTask = async (task: TaskRecord, userId: string) => {
+  return task.userId === userId;
+};
+
+const validateShoppingItems = (shoppingItems: UpdateTaskRequest["shoppingItems"]) => {
+  if (!Array.isArray(shoppingItems)) {
+    throw new Error("Shopping items must be an array");
+  }
+
+  if (shoppingItems.length > 200) {
+    throw new Error("Shopping items must contain 200 items or fewer");
+  }
+
+  for (const item of shoppingItems) {
+    if (
+      !item ||
+      typeof item.name !== "string" ||
+      typeof item.category !== "string" ||
+      typeof item.checked !== "boolean"
+    ) {
+      throw new Error("Shopping items must include name, category, and checked");
+    }
+
+    if (item.name.trim().length === 0 || item.name.length > 200) {
+      throw new Error("Shopping item names must be between 1 and 200 characters");
+    }
+
+    if (item.category.trim().length === 0 || item.category.length > 100) {
+      throw new Error("Shopping item categories must be between 1 and 100 characters");
+    }
+  }
+};
 
 const ensureFamilyMembership = async (familyId: string, userId: string) => {
   const familyDoc = await adminDb.collection("familyGroups").doc(familyId).get();
@@ -125,6 +183,64 @@ export const analyzeAndCreateTask = async (
 
   await taskRef.set(taskData);
   return taskData;
+};
+
+export const updateTask = async (
+  taskId: string,
+  updates: UpdateTaskRequest,
+  userId: string
+): Promise<TaskRecord> => {
+  if (!taskId) {
+    throw new Error("Task ID is required");
+  }
+
+  const allowedKeys = Object.keys(updates);
+  if (allowedKeys.length === 0) {
+    throw new Error("At least one field must be provided");
+  }
+
+  if (allowedKeys.some((key) => !["status", "shoppingItems"].includes(key))) {
+    throw new Error("Only status and shoppingItems can be updated");
+  }
+
+  if (updates.status !== undefined && !["pending", "completed"].includes(updates.status)) {
+    throw new Error("Status must be pending or completed");
+  }
+
+  if (updates.shoppingItems !== undefined) {
+    validateShoppingItems(updates.shoppingItems);
+  }
+
+  const task = await getTaskById(taskId);
+  const canUpdate = await canUpdateTask(task, userId);
+  if (!canUpdate) {
+    throw new Error("Access denied");
+  }
+
+  const nextTask = {
+    ...task,
+    ...updates,
+  };
+
+  await adminDb
+    .collection("tasks")
+    .doc(taskId)
+    .update(updates as Partial<Pick<TaskRecord, "status" | "shoppingItems">>);
+  return nextTask;
+};
+
+export const deleteTask = async (taskId: string, userId: string) => {
+  if (!taskId) {
+    throw new Error("Task ID is required");
+  }
+
+  const task = await getTaskById(taskId);
+  const canDelete = await canDeleteTask(task, userId);
+  if (!canDelete) {
+    throw new Error("Only the task owner can delete this task");
+  }
+
+  await adminDb.collection("tasks").doc(taskId).delete();
 };
 
 export const createSharedTask = async (params: CreateTaskParams) => {

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -2,25 +2,37 @@ import { auth } from "../firebase.js";
 import type {
   AnalyzeAndCreateTaskRequest,
   AnalyzeAndCreateTaskResponse,
+  TaskRecord,
+  UpdateTaskRequest,
 } from "../shared/taskTypes.js";
 
-export type { AnalyzeAndCreateTaskRequest, AnalyzeAndCreateTaskResponse };
+export type {
+  AnalyzeAndCreateTaskRequest,
+  AnalyzeAndCreateTaskResponse,
+  TaskRecord,
+  UpdateTaskRequest,
+};
 
-export async function analyzeAndCreateTask(
-  payload: AnalyzeAndCreateTaskRequest
-): Promise<AnalyzeAndCreateTaskResponse> {
+async function getAuthHeaders() {
   const user = auth.currentUser;
   if (!user) {
     throw new Error("User not authenticated");
   }
 
   const token = await user.getIdToken();
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function analyzeAndCreateTask(
+  payload: AnalyzeAndCreateTaskRequest
+): Promise<AnalyzeAndCreateTaskResponse> {
+  const headers = await getAuthHeaders();
   const response = await fetch("/api/tasks/analyze-and-create", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
+    headers,
     body: JSON.stringify(payload),
   });
 
@@ -30,4 +42,33 @@ export async function analyzeAndCreateTask(
   }
 
   return response.json();
+}
+
+export async function updateTask(taskId: string, payload: UpdateTaskRequest): Promise<TaskRecord> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`/api/tasks/${taskId}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to update task");
+  }
+
+  return response.json();
+}
+
+export async function deleteTask(taskId: string): Promise<void> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`/api/tasks/${taskId}`, {
+    method: "DELETE",
+    headers,
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to delete task");
+  }
 }

--- a/src/shared/taskTypes.ts
+++ b/src/shared/taskTypes.ts
@@ -23,3 +23,8 @@ export interface AnalyzeAndCreateTaskRequest {
 }
 
 export type AnalyzeAndCreateTaskResponse = TaskRecord;
+
+export interface UpdateTaskRequest {
+  status?: "pending" | "completed";
+  shoppingItems?: ShoppingItem[];
+}


### PR DESCRIPTION
Refs #2

## Summary
- add authenticated backend endpoints for task update and delete flows
- restrict updates to status and shoppingItems with server-side validation
- switch the frontend to use the new API instead of direct Firestore writes

## Verification
- npm run lint
- npm run build
- PATCH /api/tasks/:taskId without auth returns 401
- DELETE /api/tasks/:taskId without auth returns 401