### PR TITLE
Move category writes behind backend API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,18 +8,17 @@ import {
 } from 'firebase/auth';
 import { 
   collection, 
-  addDoc, 
   query, 
   where, 
   onSnapshot, 
-  deleteDoc, 
-  doc,
-  serverTimestamp, 
   orderBy,
-  getDocs,
   or
 } from 'firebase/firestore';
 import { auth, db } from './firebase';
+import {
+  createCategory as createCategoryOnServer,
+  deleteCategory as deleteCategoryOnServer,
+} from './services/categoryService';
 import type { ShoppingItem } from './services/geminiService';
 import {
   analyzeAndCreateTask,
@@ -249,33 +248,28 @@ function AppContent() {
     if (!user || !newCategoryName.trim()) return;
 
     try {
-      await addDoc(collection(db, 'categories'), {
+      await createCategoryOnServer({
         name: newCategoryName.trim(),
-        userId: user.uid,
         familyId: selectedFamilyId || null,
-        createdAt: serverTimestamp()
       });
       setNewCategoryName('');
       toast.success("카테고리가 추가되었습니다.");
     } catch (error) {
       console.error("Add category error:", error);
-      toast.error("카테고리 추가에 실패했습니다.");
+      const message = error instanceof Error ? error.message : "카테고리 추가에 실패했습니다.";
+      toast.error(message);
     }
   };
 
   const deleteCategory = async (id: string) => {
     if (!window.confirm("이 카테고리와 포함된 모든 할 일이 삭제됩니다. 계속하시겠습니까?")) return;
     try {
-      // Delete tasks in category first
-      const q = query(collection(db, 'tasks'), where('categoryId', '==', id));
-      const snapshot = await getDocs(q);
-      const deletePromises = snapshot.docs.map(d => deleteDoc(doc(db, 'tasks', d.id)));
-      await Promise.all(deletePromises);
-      await deleteDoc(doc(db, 'categories', id));
+      await deleteCategoryOnServer(id);
       toast.success("카테고리가 삭제되었습니다.");
     } catch (error) {
       console.error("Delete category error:", error);
-      toast.error("카테고리 삭제에 실패했습니다.");
+      const message = error instanceof Error ? error.message : "카테고리 삭제에 실패했습니다.";
+      toast.error(message);
     }
   };
 

--- a/src/server/controllers/categoryController.ts
+++ b/src/server/controllers/categoryController.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from "express";
+import * as categoryService from "../services/categoryService.js";
+
+export const createCategory = async (req: Request, res: Response) => {
+  try {
+    const { name, familyId } = req.body;
+    // @ts-ignore
+    const user = req.user;
+
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return res.status(400).json({ error: "Category name is required" });
+    }
+
+    if (familyId !== undefined && familyId !== null && typeof familyId !== "string") {
+      return res.status(400).json({ error: "Family ID must be a string" });
+    }
+
+    const category = await categoryService.createCategory(name, user.uid, familyId ?? null);
+    res.status(201).json(category);
+  } catch (error: any) {
+    console.error("Error creating category:", error);
+    res.status(400).json({ error: error.message || "Failed to create category" });
+  }
+};
+
+export const deleteCategory = async (req: Request, res: Response) => {
+  try {
+    const { categoryId } = req.params;
+    // @ts-ignore
+    const user = req.user;
+
+    if (!categoryId) {
+      return res.status(400).json({ error: "Category ID is required" });
+    }
+
+    await categoryService.deleteCategory(categoryId, user.uid);
+    res.status(204).send();
+  } catch (error: any) {
+    console.error("Error deleting category:", error);
+    const statusCode =
+      error.message === "Category not found"
+        ? 404
+        : error.message === "Only the category owner can delete this category"
+          ? 403
+          : 400;
+    res.status(statusCode).json({ error: error.message || "Failed to delete category" });
+  }
+};

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -1,4 +1,8 @@
 import { Router } from "express";
+import {
+  createCategory,
+  deleteCategory,
+} from "../controllers/categoryController.js";
 import { getProfile } from "../controllers/userController.js";
 import {
   createFamily,
@@ -26,6 +30,10 @@ router.get("/families", authMiddleware, getMyFamilies);
 router.post("/family/create", authMiddleware, createFamily);
 router.post("/family/invite", authMiddleware, generateInvite);
 router.post("/family/join", authMiddleware, joinFamily);
+
+// Category routes
+router.post("/categories", authMiddleware, createCategory);
+router.delete("/categories/:categoryId", authMiddleware, deleteCategory);
 
 // Task routes
 router.post("/analyze-task", authMiddleware, analyzeTask);

--- a/src/server/services/categoryService.ts
+++ b/src/server/services/categoryService.ts
@@ -1,0 +1,79 @@
+import { Timestamp } from "firebase-admin/firestore";
+import type { CategoryRecord } from "../../shared/categoryTypes.js";
+import { adminDb } from "../firebaseAdmin.js";
+
+const ensureFamilyMembership = async (familyId: string, userId: string) => {
+  const familyDoc = await adminDb.collection("familyGroups").doc(familyId).get();
+  if (!familyDoc.exists) {
+    throw new Error("Family group not found");
+  }
+
+  const familyData = familyDoc.data();
+  if (!familyData?.members.includes(userId)) {
+    throw new Error("User is not a member of this family group");
+  }
+};
+
+const getCategoryById = async (categoryId: string): Promise<CategoryRecord> => {
+  const categoryDoc = await adminDb.collection("categories").doc(categoryId).get();
+  if (!categoryDoc.exists) {
+    throw new Error("Category not found");
+  }
+
+  return {
+    id: categoryDoc.id,
+    ...(categoryDoc.data() as Omit<CategoryRecord, "id">),
+  } as CategoryRecord;
+};
+
+export const createCategory = async (
+  name: string,
+  userId: string,
+  familyId?: string | null
+): Promise<CategoryRecord> => {
+  const trimmedName = name.trim();
+  if (!trimmedName) {
+    throw new Error("Category name is required");
+  }
+
+  if (trimmedName.length > 100) {
+    throw new Error("Category name must be 100 characters or fewer");
+  }
+
+  if (familyId) {
+    await ensureFamilyMembership(familyId, userId);
+  }
+
+  const categoryRef = adminDb.collection("categories").doc();
+  const category: CategoryRecord = {
+    id: categoryRef.id,
+    name: trimmedName,
+    userId,
+    familyId: familyId ?? null,
+    createdAt: Timestamp.now(),
+  };
+
+  await categoryRef.set(category);
+  return category;
+};
+
+export const deleteCategory = async (categoryId: string, userId: string) => {
+  if (!categoryId) {
+    throw new Error("Category ID is required");
+  }
+
+  const category = await getCategoryById(categoryId);
+  if (category.userId !== userId) {
+    throw new Error("Only the category owner can delete this category");
+  }
+
+  const tasksSnapshot = await adminDb.collection("tasks").where("categoryId", "==", categoryId).get();
+  const batch = adminDb.batch();
+
+  tasksSnapshot.docs.forEach((taskDoc) => {
+    batch.delete(taskDoc.ref);
+  });
+  batch.delete(adminDb.collection("categories").doc(categoryId));
+
+  await batch.commit();
+};

--- a/src/services/categoryService.ts
+++ b/src/services/categoryService.ts
@@ -1,0 +1,49 @@
+import { auth } from "../firebase.js";
+import type {
+  CategoryRecord,
+  CreateCategoryRequest,
+} from "../shared/categoryTypes.js";
+
+export type { CategoryRecord, CreateCategoryRequest };
+
+async function getAuthHeaders() {
+  const user = auth.currentUser;
+  if (!user) {
+    throw new Error("User not authenticated");
+  }
+
+  const token = await user.getIdToken();
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function createCategory(payload: CreateCategoryRequest): Promise<CategoryRecord> {
+  const headers = await getAuthHeaders();
+  const response = await fetch("/api/categories", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to create category");
+  }
+
+  return response.json();
+}
+
+export async function deleteCategory(categoryId: string): Promise<void> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`/api/categories/${categoryId}`, {
+    method: "DELETE",
+    headers,
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to delete category");
+  }
+}

--- a/src/shared/categoryTypes.ts
+++ b/src/shared/categoryTypes.ts
@@ -1,0 +1,12 @@
+export interface CategoryRecord {
+  id: string;
+  name: string;
+  userId: string;
+  familyId?: string | null;
+  createdAt: unknown;
+}
+
+export interface CreateCategoryRequest {
+  name: string;
+  familyId?: string | null;
+}


### PR DESCRIPTION
Refs #2

## Summary
- add authenticated backend endpoints for category create and delete flows
- delete categories server-side and batch-delete linked tasks in the same operation
- switch the frontend to use the new category API instead of direct Firestore writes

## Verification
- npm run lint
- npm run build
- POST /api/categories without auth returns 401
- DELETE /api/categories/:categoryId without auth returns 401