### PR TITLE
Define Firestore composite indexes (#14)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,8 @@
   "firestore": [
     {
       "database": "task-organizer-main",
-      "rules": "firestore.rules"
+      "rules": "firestore.rules",
+      "indexes": "firestore.indexes.json"
     }
   ]
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,54 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "categories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "categories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "familyId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "categories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "familyId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "priority", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "familyId", "order": "ASCENDING" },
+        { "fieldPath": "priority", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "familyId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- 신규 `firestore.indexes.json` 추가 — 현재 클라이언트/백엔드 쿼리에 필요한 복합 인덱스 6개 정의
- `firebase.json` 의 firestore 블록에 `indexes` 경로 등록 → `firebase deploy --only firestore:indexes` 로 배포 가능

## 인덱스 도출 근거

| Collection | Index | 사용 위치 |
|---|---|---|
| categories | (userId, createdAt) | `App.tsx` 비-가족 사용자, `or(...)` 쿼리의 userId 분기 |
| categories | (familyId, createdAt) | `App.tsx` `or(...)` 쿼리의 familyId 분기, `taskService.ts` family scope |
| categories | (userId, familyId, createdAt) | `taskService.getCategoriesForScope` 의 personal scope (`familyId == null`) |
| tasks | (userId, priority) | `App.tsx` 비-가족 사용자, `or(...)` 쿼리의 userId 분기 |
| tasks | (familyId, priority) | `App.tsx` `or(...)` 쿼리의 familyId 분기 |
| tasks | (familyId, createdAt) | `taskService.getFamilyTasks` |

> Firestore의 `or()` 쿼리는 각 분기별로 별도 인덱스가 필요합니다.

## Test plan
- [x] `npm run lint` 통과
- [x] JSON 파싱 확인 (`firebase.json`, `firestore.indexes.json`)
- [ ] (배포 시) `firebase deploy --only firestore:indexes --project <prod-id>` 성공
- [ ] (배포 후) 클라이언트에서 가족 그룹이 있는 사용자로 로그인 → 카테고리/태스크 로딩 시 콘솔에 인덱스 오류 없음
- [ ] (배포 후) 가족 그룹 멤버로 `/tasks/family/:familyId` 호출 시 정렬된 결과 반환

Closes #14