### PR TITLE
Lock down Firestore Security Rules to backend-only writes (#12)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,49 +2,38 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     // ===============================================================
+    // Write Posture
+    // ===============================================================
+    // All writes go through the backend API, which uses the Firebase
+    // Admin SDK and therefore bypasses these rules. Client writes are
+    // denied across every collection. Reads remain restricted to the
+    // owner or a family member, since the client subscribes via
+    // onSnapshot for realtime updates.
+    //
+    // ===============================================================
     // Assumed Data Model
     // ===============================================================
     //
     // Collection: categories
-    // Document ID: auto-generated
     // Fields:
-    //   - name: string (required) - Category name
+    //   - name: string (required)
     //   - userId: string (required) - Owner's UID
     //   - familyId: string (optional) - ID of the family group
-    //   - createdAt: timestamp (required) - Creation time
+    //   - createdAt: timestamp (required)
     //
     // Collection: tasks
-    // Document ID: auto-generated
     // Fields:
-    //   - title: string (required) - Task title
-    //   - description: string (optional) - Task details
-    //   - categoryId: string (required) - Reference to category
-    //   - familyId: string (optional) - ID of the family group
-    //   - priority: number (required, 1-5) - AI-calculated priority
-    //   - status: string (required, 'pending'|'completed') - Task status
-    //   - aiReasoning: string (optional) - AI's explanation
-    //   - dueDate: string (optional, YYYY-MM-DD) - Extracted date
-    //   - reminderTime: string (optional, HH:mm) - Extracted time
-    //   - isShoppingList: bool (optional) - Is it a shopping list
-    //   - shoppingItems: list (optional) - List of items
-    //   - userId: string (required) - Owner's UID
-    //   - createdAt: timestamp (required) - Creation time
+    //   - title, description, categoryId, priority, status,
+    //     aiReasoning, dueDate, reminderTime, isShoppingList,
+    //     shoppingItems, userId, familyId, createdAt
     //
     // Collection: familyGroups
-    // Document ID: auto-generated
     // Fields:
-    //   - name: string (required) - Group name
-    //   - ownerId: string (required) - Owner's UID
-    //   - members: list (required) - List of member UIDs
-    //   - createdAt: timestamp (required) - Creation time
+    //   - name, ownerId, members, createdAt
     //
     // Collection: invites
-    // Document ID: auto-generated
     // Fields:
-    //   - familyId: string (required) - Group ID
-    //   - code: string (required) - Invite code
-    //   - expiresAt: timestamp (required) - Expiry time
-    //   - createdAt: timestamp (required) - Creation time
+    //   - familyId, code, expiresAt, createdAt
     //
     // ===============================================================
 
@@ -58,69 +47,33 @@ service cloud.firestore {
     }
 
     function isMember(familyId) {
-      return isAuthenticated() && 
+      return isAuthenticated() &&
              get(/databases/$(database)/documents/familyGroups/$(familyId)).data.members.hasAny([request.auth.uid]);
     }
 
     function canAccess(data) {
-      return isOwner(data.userId) || 
+      return isOwner(data.userId) ||
              ('familyId' in data && data.familyId != null && isMember(data.familyId));
-    }
-
-    function isValidCategory(data) {
-      return data.keys().hasAll(['name', 'userId', 'createdAt']) &&
-             data.name is string && data.name.size() > 0 && data.name.size() < 100 &&
-             data.userId == request.auth.uid &&
-             data.createdAt is timestamp &&
-             (!('familyId' in data) || (data.familyId == null || (data.familyId is string && isMember(data.familyId))));
-    }
-
-    function isValidTask(data) {
-      return data.keys().hasAll(['title', 'categoryId', 'priority', 'status', 'userId', 'createdAt']) &&
-             data.title is string && data.title.size() > 0 && data.title.size() < 500 &&
-             data.categoryId is string &&
-             data.priority is number && data.priority >= 1 && data.priority <= 5 &&
-             data.status in ['pending', 'completed'] &&
-             data.userId == request.auth.uid &&
-             data.createdAt is timestamp &&
-             (!('familyId' in data) || (data.familyId == null || (data.familyId is string && isMember(data.familyId)))) &&
-             (!('description' in data) || (data.description is string && data.description.size() < 2000)) &&
-             (!('aiReasoning' in data) || (data.aiReasoning is string && data.aiReasoning.size() < 2000)) &&
-             (!('dueDate' in data) || (data.dueDate == null || (data.dueDate is string && data.dueDate.matches("^\\d{4}-\\d{2}-\\d{2}$")))) &&
-             (!('reminderTime' in data) || (data.reminderTime == null || (data.reminderTime is string && data.reminderTime.matches("^\\d{2}:\\d{2}$")))) &&
-             (!('isShoppingList' in data) || data.isShoppingList is bool) &&
-             (!('shoppingItems' in data) || data.shoppingItems is list);
     }
 
     match /categories/{categoryId} {
       allow read: if canAccess(resource.data);
-      allow create: if isAuthenticated() && isValidCategory(request.resource.data);
-      allow update: if canAccess(resource.data) && isValidCategory(request.resource.data);
-      allow delete: if isOwner(resource.data.userId);
+      allow write: if false; // Backend-only via Admin SDK
     }
 
     match /tasks/{taskId} {
       allow read: if canAccess(resource.data);
-      allow create: if isAuthenticated() && isValidTask(request.resource.data);
-      allow update: if canAccess(resource.data) && isValidTask(request.resource.data);
-      allow delete: if isOwner(resource.data.userId);
+      allow write: if false; // Backend-only via Admin SDK
     }
 
     match /familyGroups/{familyId} {
       allow read: if isMember(familyId);
-      // Create is handled via backend API, but rules should still be safe
-      allow create: if false; 
-      allow update: if isMember(familyId) && 
-                      request.resource.data.diff(resource.data).affectedKeys().hasOnly(['name', 'members']) &&
-                      (request.resource.data.ownerId == resource.data.ownerId);
-      allow delete: if isAuthenticated() && resource.data.ownerId == request.auth.uid;
+      allow write: if false; // Backend-only via Admin SDK
     }
 
     match /invites/{inviteId} {
-      allow read: if isAuthenticated(); // To validate code
-      allow create: if false; // Handled via backend API
-      allow update: if false;
-      allow delete: if false;
+      allow read: if isAuthenticated(); // Clients validate codes during join flow
+      allow write: if false; // Backend-only via Admin SDK
     }
   }
 }


### PR DESCRIPTION
## Summary
- 모든 클라이언트 직접 쓰기를 `allow write: if false` 로 잠금
- 읽기는 기존대로 owner / family member 만 허용 (`onSnapshot` 구독 유지)
- 사용되지 않게 된 `isValidCategory` / `isValidTask` 검증자 제거

## 배경

리뷰 결과(2026-05-01) 클라이언트 측 Firestore 직접 쓰기는 이미 0건. 모든 CRUD가 백엔드 API → Firebase Admin SDK 경로로 처리됨 (Admin SDK 는 Security Rules 를 우회). 이 PR 은 룰 자체에서도 클라이언트 쓰기를 거부하도록 정비하여 **방어 계층을 한 번 더 추가**합니다.

## Auth 토큰 검증 일관성 점검

`src/server/routes/api.ts` 의 12개 라우트 모두 `authMiddleware` 적용 확인:
- `/profile`, `/families`, `/family/{create,invite,join}`
- `/categories`, `/categories/:id` (DELETE)
- `/analyze-task`, `/tasks/analyze-and-create`, `/tasks/shared`
- `/tasks/:taskId` (PATCH/DELETE), `/tasks/family/:familyId`

`src/server/middleware/auth.ts` 는 Bearer 토큰 → `verifyIdToken()` → `req.user` 패턴으로 일관됨.

## 변경된 룰

| Collection | Read | Write |
|---|---|---|
| categories | `canAccess(resource.data)` | `false` |
| tasks | `canAccess(resource.data)` | `false` |
| familyGroups | `isMember(familyId)` | `false` |
| invites | `isAuthenticated()` (코드 검증용) | `false` |

## Test plan
- [x] `npm run lint` 통과
- [ ] (배포 전) Firebase Emulator 또는 dev 프로젝트에 룰 배포 후, 클라이언트 SDK 로 `addDoc/updateDoc/deleteDoc` 시도 시 `permission-denied` 반환 확인
- [ ] (배포 후) 백엔드 API 경유 CRUD 정상 동작 확인 (Admin SDK 는 룰 우회)
- [ ] (배포 후) 클라이언트 `onSnapshot` 으로 카테고리/태스크 읽기 정상 동작 확인 (가족 그룹 사용자 / 단독 사용자 모두)

## 배포 명령
\`\`\`bash
firebase deploy --only firestore:rules --project <project-id>
\`\`\`

Closes #12