### PR TITLE
Add GitHub Actions workflow to run Firestore rules tests on PRs (#35)

### DIFF
--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -1,0 +1,51 @@
+name: Firestore Rules Tests
+
+on:
+  pull_request:
+    paths:
+      - 'firestore.rules'
+      - 'tests/rules/**'
+      - 'vitest.rules.config.ts'
+      - 'firebase.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/firestore-rules-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'firestore.rules'
+      - 'tests/rules/**'
+      - 'vitest.rules.config.ts'
+      - 'firebase.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/firestore-rules-test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: rules-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rules:
+    name: firestore.rules emulator suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Firestore rules tests
+        run: npm run test:rules


### PR DESCRIPTION
## Summary

Wires the `npm run test:rules` suite (added in PR #34) into GitHub Actions so a rule regression blocks the merge automatically. The job runs only when relevant files change — unrelated PRs are not slowed down.

## What's in the workflow

`.github/workflows/firestore-rules-test.yml`:
- **Triggers**: `pull_request` and `push: branches: [main]`, both with a `paths:` filter scoped to `firestore.rules`, `tests/rules/**`, `vitest.rules.config.ts`, `firebase.json`, `package.json`, `package-lock.json`, and the workflow file itself. `workflow_dispatch` is also enabled for manual re-runs.
- **Concurrency**: cancels superseded runs on the same ref so a force-push doesn't pile up duplicates.
- **Job** (`ubuntu-latest`, 10-min timeout):
  1. `actions/checkout@v4`
  2. `actions/setup-node@v4` (Node 20 LTS) with npm cache
  3. `actions/setup-java@v4` (Temurin JDK 21) — required by the Firestore emulator
  4. `npm ci`
  5. `npm run test:rules`

## Why these triggers

A naive `on: pull_request:` would burn CI minutes on every unrelated change. The `paths:` filter ensures the job runs only when the rules, tests, or their direct dependencies change. The `push: branches: [main]` keeps a safety net so a rule that somehow slips into main without going through a triggered PR still surfaces a failing build. `workflow_dispatch` is convenient when bumping a dep or debugging.

## Verification

- Locally: `PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH" npm run test:rules` → 28/28 passed (verified pre-merge of PR #34)
- This PR itself touches `package.json` / workflow file paths, so the workflow will run against this PR — that is the green-check verification.

## Out of scope

- Documentation that mentions CI verifies rules — `AGENTS.md` already tells contributors when to run the suite locally, and a CI status check on the PR is self-documenting. Skipping to keep this PR pure infra.

## Test plan

- [x] Workflow YAML lints (no parse errors, valid action versions)
- [ ] First CI run on this PR is green (verified by reviewer post-push)
- [ ] An unrelated file change (e.g., a one-line README edit) does NOT trigger this workflow — confirmed by the `paths:` filter spec; can be re-verified empirically in a follow-up PR if desired

Closes #35