### PR TITLE
Prevent duplicate category names within the same scope (#40)

### DIFF
--- a/src/server/services/categoryService.ts
+++ b/src/server/services/categoryService.ts
@@ -44,6 +44,20 @@ export const createCategory = async (
     await ensureFamilyMembership(familyId, userId);
   }
 
+  // Duplicate check within the same scope (case-insensitive)
+  const scopeQuery = familyId
+    ? adminDb.collection("categories").where("familyId", "==", familyId)
+    : adminDb.collection("categories").where("userId", "==", userId).where("familyId", "==", null);
+
+  const existing = await scopeQuery.get();
+  const normalizedNew = trimmedName.toLowerCase();
+  const isDuplicate = existing.docs.some(
+    (doc) => (doc.data().name as string).trim().toLowerCase() === normalizedNew
+  );
+  if (isDuplicate) {
+    throw new Error("A category with this name already exists");
+  }
+
   const categoryRef = adminDb.collection("categories").doc();
   const category: CategoryRecord = {
     id: categoryRef.id,


### PR DESCRIPTION
## Summary

`createCategory`에 중복 이름 체크 추가. 같은 스코프에 동일 이름(대소문자 무시) 카테고리가 이미 있으면 400을 반환합니다.

## 변경

`src/server/services/categoryService.ts`:
- 카테고리 생성 전 스코프 내 기존 카테고리 조회
- 개인: `userId + familyId == null` / 가족: `familyId` 기준
- `trimmedName.toLowerCase()` 비교

## 테스트

- `npm run lint` 통과
- 로컬에서 같은 이름 카테고리 두 번 추가 시 두 번째 요청이 400 반환 확인

Fixes #40