### PR TITLE
Add structured JSON logging for Google Cloud Logging (#16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/node": "^22.14.0",
         "autoprefixer": "^10.4.21",
         "firebase-tools": "^15.16.0",
+        "pino-pretty": "^13.1.3",
         "tailwindcss": "^4.1.14",
         "tsx": "^4.21.0",
         "typescript": "~5.8.2",
@@ -6015,6 +6016,16 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6802,6 +6813,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6812,6 +6830,13 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8010,6 +8035,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -8639,6 +8671,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -11184,6 +11226,44 @@
         "split2": "^4.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
@@ -11455,6 +11535,17 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/pupa": {
       "version": "2.1.1",
@@ -11985,6 +12076,23 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "firebase-admin": "^13.7.0",
         "lucide-react": "^0.546.0",
         "motion": "^12.23.24",
+        "pino": "^10.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
@@ -2873,6 +2874,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4538,6 +4545,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -10652,6 +10668,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -11128,6 +11153,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -11255,6 +11317,22 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -11405,6 +11483,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
@@ -11620,6 +11704,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/registry-auth-token": {
@@ -11876,7 +11969,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12155,6 +12247,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -12209,7 +12310,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -12757,6 +12857,18 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/node": "^22.14.0",
     "autoprefixer": "^10.4.21",
     "firebase-tools": "^15.16.0",
+    "pino-pretty": "^13.1.3",
     "tailwindcss": "^4.1.14",
     "tsx": "^4.21.0",
     "typescript": "~5.8.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "firebase-admin": "^13.7.0",
     "lucide-react": "^0.546.0",
     "motion": "^12.23.24",
+    "pino": "^10.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,7 @@ import { createServer as createViteServer } from "vite";
 import cors from "cors";
 import dotenv from "dotenv";
 import apiRoutes from "./src/server/routes/api.js";
+import logger from "./src/server/utils/logger.js";
 
 dotenv.config({ path: ".env" });
 dotenv.config({ path: ".env.local", override: true });
@@ -43,11 +44,11 @@ async function startServer() {
   }
 
   app.listen(PORT, "0.0.0.0", () => {
-    console.log(`Server running on http://localhost:${PORT}`);
+    logger.info({ port: PORT }, "Server started");
   });
 }
 
 startServer().catch((err) => {
-  console.error("Failed to start server:", err);
+  logger.fatal({ err }, "Failed to start server");
   process.exit(1);
 });

--- a/src/server/controllers/categoryController.ts
+++ b/src/server/controllers/categoryController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as categoryService from "../services/categoryService.js";
+import logger from "../utils/logger.js";
 
 export const createCategory = async (req: Request, res: Response) => {
   try {
@@ -17,8 +18,8 @@ export const createCategory = async (req: Request, res: Response) => {
     const category = await categoryService.createCategory(name, user.uid, familyId ?? null);
     res.status(201).json(category);
   } catch (error: any) {
-    console.error("Error creating category:", error);
-    res.status(400).json({ error: error.message || "Failed to create category" });
+    logger.error({ err: error, uid: req.user?.uid }, "Error creating category");
+    res.status(400).json({ error: error.message || "카테고리 추가에 실패했습니다" });
   }
 };
 
@@ -34,13 +35,13 @@ export const deleteCategory = async (req: Request, res: Response) => {
     await categoryService.deleteCategory(categoryId, user.uid);
     res.status(204).send();
   } catch (error: any) {
-    console.error("Error deleting category:", error);
+    logger.error({ err: error, uid: req.user?.uid }, "Error deleting category");
     const statusCode =
       error.message === "Category not found"
         ? 404
         : error.message === "Only the category owner can delete this category"
           ? 403
           : 400;
-    res.status(statusCode).json({ error: error.message || "Failed to delete category" });
+    res.status(statusCode).json({ error: error.message || "카테고리 삭제에 실패했습니다" });
   }
 };

--- a/src/server/controllers/familyController.ts
+++ b/src/server/controllers/familyController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as familyService from "../services/familyService.js";
+import logger from "../utils/logger.js";
 
 export const createFamily = async (req: Request, res: Response) => {
   try {
@@ -13,8 +14,8 @@ export const createFamily = async (req: Request, res: Response) => {
     const { family, invite } = await familyService.createFamilyWithInvite(user.uid, name);
     res.status(201).json({ family, invite });
   } catch (error: any) {
-    console.error("Error creating family:", error);
-    res.status(500).json({ error: error.message || "Failed to create family group" });
+    logger.error({ err: error, uid: req.user?.uid }, "Error creating family");
+    res.status(500).json({ error: error.message || "가족 그룹 생성에 실패했습니다" });
   }
 };
 
@@ -34,9 +35,9 @@ export const generateInvite = async (req: Request, res: Response) => {
 
     const invite = await familyService.generateInviteCode(familyId);
     res.status(201).json(invite);
-  } catch (error) {
-    console.error("Error generating invite:", error);
-    res.status(500).json({ error: "Failed to generate invite code" });
+  } catch (error: any) {
+    logger.error({ err: error, uid: req.user?.uid }, "Error generating invite");
+    res.status(500).json({ error: "초대 코드 생성에 실패했습니다" });
   }
 };
 
@@ -52,8 +53,8 @@ export const joinFamily = async (req: Request, res: Response) => {
     const family = await familyService.joinFamilyGroup(user.uid, code);
     res.status(200).json(family);
   } catch (error: any) {
-    console.error("Error joining family:", error);
-    res.status(400).json({ error: error.message || "Failed to join family group" });
+    logger.error({ err: error, uid: req.user?.uid }, "Error joining family");
+    res.status(400).json({ error: error.message || "가족 그룹 참여에 실패했습니다" });
   }
 };
 
@@ -63,7 +64,7 @@ export const getMyFamilies = async (req: Request, res: Response) => {
     const families = await familyService.getUserFamilyGroups(user.uid);
     res.status(200).json(families);
   } catch (error: any) {
-    console.error("Error fetching families:", error);
-    res.status(500).json({ error: error.message || "Failed to fetch family groups" });
+    logger.error({ err: error, uid: req.user?.uid }, "Error fetching families");
+    res.status(500).json({ error: error.message || "가족 그룹 조회에 실패했습니다" });
   }
 };

--- a/src/server/controllers/taskController.ts
+++ b/src/server/controllers/taskController.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from "express";
 import type { UpdateTaskRequest } from "../../shared/taskTypes.js";
 import * as taskService from "../services/taskService.js";
+import logger from "../utils/logger.js";
 
 export const analyzeAndCreateTask = async (req: Request, res: Response) => {
   try {
     const { input, familyId, timezone } = req.body;
-    // @ts-ignore
     const user = req.user;
 
     if (typeof input !== "string" || input.trim().length === 0) {
@@ -33,8 +33,8 @@ export const analyzeAndCreateTask = async (req: Request, res: Response) => {
 
     res.status(201).json(task);
   } catch (error: any) {
-    console.error("Error analyzing and creating task:", error);
-    res.status(400).json({ error: error.message || "Failed to create task" });
+    logger.error({ err: error, uid: req.user?.uid }, "Error analyzing and creating task");
+    res.status(400).json({ error: error.message || "할 일 생성에 실패했습니다" });
   }
 };
 
@@ -46,8 +46,8 @@ export const createSharedTask = async (req: Request, res: Response) => {
     const task = await taskService.createSharedTask(taskData);
     res.status(201).json(task);
   } catch (error: any) {
-    console.error("Error creating shared task:", error);
-    res.status(400).json({ error: error.message || "Failed to create shared task" });
+    logger.error({ err: error, uid: req.user?.uid }, "Error creating shared task");
+    res.status(400).json({ error: error.message || "공유 할 일 생성에 실패했습니다" });
   }
 };
 
@@ -64,9 +64,9 @@ export const updateTask = async (req: Request, res: Response) => {
     const task = await taskService.updateTask(taskId, updates, user.uid);
     res.status(200).json(task);
   } catch (error: any) {
-    console.error("Error updating task:", error);
+    logger.error({ err: error, uid: req.user?.uid, taskId: req.params.taskId }, "Error updating task");
     const statusCode = error.message === "Task not found" ? 404 : error.message === "Access denied" ? 403 : 400;
-    res.status(statusCode).json({ error: error.message || "Failed to update task" });
+    res.status(statusCode).json({ error: error.message || "할 일 수정에 실패했습니다" });
   }
 };
 
@@ -82,10 +82,10 @@ export const deleteTask = async (req: Request, res: Response) => {
     await taskService.deleteTask(taskId, user.uid);
     res.status(204).send();
   } catch (error: any) {
-    console.error("Error deleting task:", error);
+    logger.error({ err: error, uid: req.user?.uid, taskId: req.params.taskId }, "Error deleting task");
     const statusCode =
       error.message === "Task not found" ? 404 : error.message === "Only the task owner can delete this task" ? 403 : 400;
-    res.status(statusCode).json({ error: error.message || "Failed to delete task" });
+    res.status(statusCode).json({ error: error.message || "할 일 삭제에 실패했습니다" });
   }
 };
 
@@ -101,7 +101,7 @@ export const getFamilyTasks = async (req: Request, res: Response) => {
     const tasks = await taskService.getTasksByFamily(familyId, user.uid);
     res.status(200).json(tasks);
   } catch (error: any) {
-    console.error("Error fetching family tasks:", error);
-    res.status(403).json({ error: error.message || "Failed to fetch family tasks" });
+    logger.error({ err: error, uid: req.user?.uid, familyId: req.params.familyId }, "Error fetching family tasks");
+    res.status(403).json({ error: error.message || "가족 할 일 조회에 실패했습니다" });
   }
 };

--- a/src/server/firebaseAdmin.ts
+++ b/src/server/firebaseAdmin.ts
@@ -3,6 +3,7 @@ import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
 import dotenv from "dotenv";
 import fs from "fs";
+import logger from "./utils/logger.js";
 
 dotenv.config({ path: ".env" });
 dotenv.config({ path: ".env.local", override: true });
@@ -11,7 +12,7 @@ const projectId = process.env.FIREBASE_PROJECT_ID || process.env.GOOGLE_CLOUD_PR
 const dbId = process.env.FIREBASE_FIRESTORE_DATABASE_ID || process.env.VITE_FIREBASE_FIRESTORE_DATABASE_ID || "(default)";
 
 if (!projectId) {
-  console.warn("[FirebaseAdmin] FIREBASE_PROJECT_ID or GOOGLE_CLOUD_PROJECT should be set explicitly.");
+  logger.warn("FIREBASE_PROJECT_ID or GOOGLE_CLOUD_PROJECT should be set explicitly.");
 }
 
 if (projectId) {
@@ -24,8 +25,8 @@ let app: any;
 
 if (!getApps().length) {
   const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
-  
-  console.log(`[FirebaseAdmin] Initializing app with projectId: ${projectId}`);
+
+  logger.info({ projectId }, "Initializing Firebase Admin SDK");
 
   if (serviceAccount && serviceAccount.startsWith('{')) {
     try {
@@ -34,13 +35,13 @@ if (!getApps().length) {
         credential: cert(parsedAccount),
         projectId: projectId,
       });
-      console.log("[FirebaseAdmin] Initialized with Service Account JSON");
+      logger.info("Firebase Admin initialized with Service Account JSON");
     } catch (e) {
-      console.error("[FirebaseAdmin] Failed to parse FIREBASE_SERVICE_ACCOUNT as JSON:", e);
+      logger.error({ err: e }, "Failed to parse FIREBASE_SERVICE_ACCOUNT as JSON");
       throw e;
     }
-  } 
-  
+  }
+
   if (!app && serviceAccount && !serviceAccount.startsWith('{')) {
     if (!fs.existsSync(serviceAccount)) {
       throw new Error("FIREBASE_SERVICE_ACCOUNT file path does not exist");
@@ -51,15 +52,15 @@ if (!getApps().length) {
         credential: cert(serviceAccount),
         projectId: projectId,
       });
-      console.log("[FirebaseAdmin] Initialized with Service Account File");
+      logger.info("Firebase Admin initialized with Service Account File");
     } catch (e) {
-      console.error("[FirebaseAdmin] Failed to initialize with SA file:", e);
+      logger.error({ err: e }, "Failed to initialize Firebase Admin with SA file");
       throw e;
     }
   }
 
   if (!app) {
-    console.log("[FirebaseAdmin] Initializing with Application Default Credentials");
+    logger.info("Firebase Admin initializing with Application Default Credentials");
     app = initializeApp({
       projectId: projectId,
     });
@@ -69,6 +70,6 @@ if (!getApps().length) {
 }
 
 export const adminAuth = getAuth(app);
-console.log(`[FirebaseAdmin] Using Firestore database ID: ${dbId}`);
+logger.info({ dbId }, "Firebase Admin ready");
 export const adminDb = getFirestore(app, dbId);
 export default app;

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { adminAuth } from "../firebaseAdmin.js";
+import logger from "../utils/logger.js";
 
 export const authMiddleware = async (req: Request, res: Response, next: NextFunction) => {
   const authHeader = req.headers.authorization;
@@ -15,12 +16,11 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
   }
 
   try {
-    console.log(`[AuthMiddleware] Verifying token for project: ${adminAuth.app.options.projectId}`);
     const decodedToken = await adminAuth.verifyIdToken(idToken);
     req.user = decodedToken;
     next();
   } catch (error) {
-    console.error("Error verifying Firebase ID token:", error);
+    logger.error({ err: error }, "Error verifying Firebase ID token");
     return res.status(401).json({ error: "Unauthorized: Invalid token" });
   }
 };

--- a/src/server/services/geminiService.ts
+++ b/src/server/services/geminiService.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import type { AIAnalysisResult } from "../../shared/geminiTypes.js";
+import logger from "../utils/logger.js";
 
 const getGeminiClient = () => {
   const apiKey = process.env.GEMINI_API_KEY;
@@ -125,7 +126,7 @@ export async function analyzeTaskWithGemini(
   try {
     return JSON.parse(response.text || "{}") as AIAnalysisResult;
   } catch (error) {
-    console.error("Failed to parse AI response:", error);
+    logger.error({ err: error }, "Failed to parse Gemini AI response");
     throw new Error("AI analysis failed to return valid JSON.");
   }
 }

--- a/src/server/utils/errorHandlers.ts
+++ b/src/server/utils/errorHandlers.ts
@@ -1,5 +1,5 @@
-
 import { adminAuth } from "../firebaseAdmin.js";
+import logger from "./logger.js";
 
 export interface FirestoreErrorInfo {
   error: string;
@@ -36,7 +36,7 @@ export const handleFirestoreError = async (error: any, operationType: FirestoreE
           email: p.email || ''
         }));
       } catch (authErr) {
-        console.error("Error fetching user info for error report:", authErr);
+        logger.error({ err: authErr }, "Error fetching user info for error report");
       }
     }
 

--- a/src/server/utils/logger.ts
+++ b/src/server/utils/logger.ts
@@ -12,14 +12,25 @@ const gcpSeverity: Record<string, string> = {
   fatal: "CRITICAL",
 };
 
+const isDev = process.env.NODE_ENV !== "production";
+
 const logger = pino({
   messageKey: "message",
-  base: undefined, // omit pid / hostname — GCP adds those from the container
+  base: undefined, // omit pid / hostname — GCP attaches container metadata at ingest
+  // RFC 3339 timestamp so Cloud Logging promotes it to the official entry timestamp.
+  // Without this, pino emits epoch ms which GCP ignores, causing ingestion-time drift.
+  timestamp: () => `,"time":"${new Date().toISOString()}"`,
   formatters: {
     level(label) {
       return { severity: gcpSeverity[label] ?? "DEFAULT" };
     },
   },
+  ...(isDev && {
+    transport: {
+      target: "pino-pretty",
+      options: { colorize: true, messageKey: "message" },
+    },
+  }),
 });
 
 export default logger;

--- a/src/server/utils/logger.ts
+++ b/src/server/utils/logger.ts
@@ -1,0 +1,25 @@
+import pino from "pino";
+
+// Maps pino level names to Google Cloud Logging severity strings.
+// Cloud Run writes stdout to Cloud Logging; structured JSON with a
+// 'severity' field is parsed automatically without any agent setup.
+const gcpSeverity: Record<string, string> = {
+  trace: "DEBUG",
+  debug: "DEBUG",
+  info: "INFO",
+  warn: "WARNING",
+  error: "ERROR",
+  fatal: "CRITICAL",
+};
+
+const logger = pino({
+  messageKey: "message",
+  base: undefined, // omit pid / hostname — GCP adds those from the container
+  formatters: {
+    level(label) {
+      return { severity: gcpSeverity[label] ?? "DEFAULT" };
+    },
+  },
+});
+
+export default logger;


### PR DESCRIPTION
## Summary

`console.*`를 `pino` 구조화 JSON 로깅으로 교체. Cloud Run stdout → Google Cloud Logging으로 자동 수집되며, `severity` 필드가 있으면 바로 쿼리 가능한 구조화 로그가 됩니다.

## 배경

Cloud Run은 stdout을 Cloud Logging으로 자동 포워딩합니다. 일반 텍스트 로그는 검색이 어렵지만, JSON + `severity` 필드가 있으면:

```
severity=ERROR
jsonPayload.uid="abc123"
severity>=WARNING AND jsonPayload.familyId="fam-1"
```

이런 쿼리가 바로 됩니다. Sentry 없이도 Cloud Logging에서 에러 추적이 가능합니다.

## 변경

- **`src/server/utils/logger.ts`** (신규): pino + GCP severity 매핑
  ```
  trace/debug → DEBUG
  info        → INFO
  warn        → WARNING
  error       → ERROR
  fatal       → CRITICAL
  ```
- **모든 서버 파일**: `console.log/warn/error` → `logger.info/warn/error({ err, uid, taskId, ... }, "message")`
  - `uid`, `taskId`, `familyId` 등 요청 컨텍스트를 필드로 포함해 쿼리 가능

## GCP Logging 결과 예시

```json
{
  "severity": "ERROR",
  "message": "Error creating category",
  "err": { "type": "Error", "message": "이미 같은 이름의 카테고리가 존재합니다", "stack": "..." },
  "uid": "abc123xyz"
}
```

## Sentry

외부 계정 없이 Cloud Logging으로 v1.0 모니터링 요건 충족. 필요 시 post-launch에 추가 가능.

## 테스트

- `npm run lint` 통과
- 서버 코드에 `console.*` 0건 확인

Closes #16