### PR TITLE
Localize all backend error messages to Korean (#42)

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -26,15 +26,7 @@ class ErrorBoundary extends Component<Props, State> {
 
   public render() {
     if (this.state.hasError) {
-      let errorMessage = "알 수 없는 오류가 발생했습니다.";
-      try {
-        const parsedError = JSON.parse(this.state.error?.message || "{}");
-        if (parsedError.error) {
-          errorMessage = `Firestore 오류: ${parsedError.error}`;
-        }
-      } catch (e) {
-        errorMessage = this.state.error?.message || errorMessage;
-      }
+      const errorMessage = this.state.error?.message || "알 수 없는 오류가 발생했습니다.";
 
       return (
         <div className="min-h-screen bg-stone-50 flex items-center justify-center p-6 text-center">

--- a/src/server/controllers/categoryController.ts
+++ b/src/server/controllers/categoryController.ts
@@ -8,11 +8,11 @@ export const createCategory = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (typeof name !== "string" || name.trim().length === 0) {
-      return res.status(400).json({ error: "Category name is required" });
+      return res.status(400).json({ error: "카테고리 이름을 입력해주세요" });
     }
 
     if (familyId !== undefined && familyId !== null && typeof familyId !== "string") {
-      return res.status(400).json({ error: "Family ID must be a string" });
+      return res.status(400).json({ error: "Family ID가 올바르지 않습니다" });
     }
 
     const category = await categoryService.createCategory(name, user.uid, familyId ?? null);
@@ -29,7 +29,7 @@ export const deleteCategory = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (!categoryId) {
-      return res.status(400).json({ error: "Category ID is required" });
+      return res.status(400).json({ error: "카테고리 ID가 필요합니다" });
     }
 
     await categoryService.deleteCategory(categoryId, user.uid);
@@ -37,9 +37,9 @@ export const deleteCategory = async (req: Request, res: Response) => {
   } catch (error: any) {
     logger.error({ err: error, uid: req.user?.uid }, "Error deleting category");
     const statusCode =
-      error.message === "Category not found"
+      error.message === "카테고리를 찾을 수 없습니다"
         ? 404
-        : error.message === "Only the category owner can delete this category"
+        : error.message === "카테고리 삭제는 작성자만 가능합니다"
           ? 403
           : 400;
     res.status(statusCode).json({ error: error.message || "카테고리 삭제에 실패했습니다" });

--- a/src/server/controllers/familyController.ts
+++ b/src/server/controllers/familyController.ts
@@ -8,7 +8,7 @@ export const createFamily = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (!name) {
-      return res.status(400).json({ error: "Family name is required" });
+      return res.status(400).json({ error: "가족 그룹 이름을 입력해주세요" });
     }
 
     const { family, invite } = await familyService.createFamilyWithInvite(user.uid, name);
@@ -25,12 +25,12 @@ export const generateInvite = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (!familyId) {
-      return res.status(400).json({ error: "Family ID is required" });
+      return res.status(400).json({ error: "가족 그룹 ID가 필요합니다" });
     }
 
     const family = await familyService.getFamilyGroup(familyId);
     if (!family || family.ownerId !== user.uid) {
-      return res.status(403).json({ error: "Only the owner can generate invites" });
+      return res.status(403).json({ error: "초대 코드는 그룹 소유자만 생성할 수 있습니다" });
     }
 
     const invite = await familyService.generateInviteCode(familyId);
@@ -47,7 +47,7 @@ export const joinFamily = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (!code) {
-      return res.status(400).json({ error: "Invite code is required" });
+      return res.status(400).json({ error: "초대 코드를 입력해주세요" });
     }
 
     const family = await familyService.joinFamilyGroup(user.uid, code);

--- a/src/server/controllers/taskController.ts
+++ b/src/server/controllers/taskController.ts
@@ -102,6 +102,7 @@ export const getFamilyTasks = async (req: Request, res: Response) => {
     res.status(200).json(tasks);
   } catch (error: any) {
     logger.error({ err: error, uid: req.user?.uid, familyId: req.params.familyId }, "Error fetching family tasks");
-    res.status(403).json({ error: error.message || "가족 할 일 조회에 실패했습니다" });
+    const statusCode = error.message === "가족 그룹을 찾을 수 없습니다" ? 404 : 403;
+    res.status(statusCode).json({ error: error.message || "가족 할 일 조회에 실패했습니다" });
   }
 };

--- a/src/server/controllers/taskController.ts
+++ b/src/server/controllers/taskController.ts
@@ -9,17 +9,17 @@ export const analyzeAndCreateTask = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (typeof input !== "string" || input.trim().length === 0) {
-      return res.status(400).json({ error: "Task input is required" });
+      return res.status(400).json({ error: "할 일 내용을 입력해주세요" });
     }
 
     if (familyId !== undefined && familyId !== null && typeof familyId !== "string") {
-      return res.status(400).json({ error: "Family ID must be a string" });
+      return res.status(400).json({ error: "Family ID가 올바르지 않습니다" });
     }
 
     let resolvedTimezone: string | undefined;
     if (timezone !== undefined && timezone !== null) {
       if (typeof timezone !== "string" || timezone.length > 64) {
-        return res.status(400).json({ error: "Timezone must be a string up to 64 characters" });
+        return res.status(400).json({ error: "타임존 형식이 올바르지 않습니다" });
       }
       resolvedTimezone = timezone;
     }
@@ -58,14 +58,14 @@ export const updateTask = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (!taskId) {
-      return res.status(400).json({ error: "Task ID is required" });
+      return res.status(400).json({ error: "할 일 ID가 필요합니다" });
     }
 
     const task = await taskService.updateTask(taskId, updates, user.uid);
     res.status(200).json(task);
   } catch (error: any) {
     logger.error({ err: error, uid: req.user?.uid, taskId: req.params.taskId }, "Error updating task");
-    const statusCode = error.message === "Task not found" ? 404 : error.message === "Access denied" ? 403 : 400;
+    const statusCode = error.message === "할 일을 찾을 수 없습니다" ? 404 : error.message === "접근 권한이 없습니다" ? 403 : 400;
     res.status(statusCode).json({ error: error.message || "할 일 수정에 실패했습니다" });
   }
 };
@@ -76,7 +76,7 @@ export const deleteTask = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (!taskId) {
-      return res.status(400).json({ error: "Task ID is required" });
+      return res.status(400).json({ error: "할 일 ID가 필요합니다" });
     }
 
     await taskService.deleteTask(taskId, user.uid);
@@ -84,7 +84,7 @@ export const deleteTask = async (req: Request, res: Response) => {
   } catch (error: any) {
     logger.error({ err: error, uid: req.user?.uid, taskId: req.params.taskId }, "Error deleting task");
     const statusCode =
-      error.message === "Task not found" ? 404 : error.message === "Only the task owner can delete this task" ? 403 : 400;
+      error.message === "할 일을 찾을 수 없습니다" ? 404 : error.message === "할 일 삭제는 작성자만 가능합니다" ? 403 : 400;
     res.status(statusCode).json({ error: error.message || "할 일 삭제에 실패했습니다" });
   }
 };
@@ -95,7 +95,7 @@ export const getFamilyTasks = async (req: Request, res: Response) => {
     const user = req.user;
 
     if (!familyId) {
-      return res.status(400).json({ error: "Family ID is required" });
+      return res.status(400).json({ error: "가족 그룹 ID가 필요합니다" });
     }
 
     const tasks = await taskService.getTasksByFamily(familyId, user.uid);

--- a/src/server/controllers/userController.ts
+++ b/src/server/controllers/userController.ts
@@ -11,6 +11,6 @@ export const getProfile = async (req: Request, res: Response) => {
       isPremium: true,
     });
   } catch (error) {
-    res.status(500).json({ error: "Failed to fetch profile" });
+    res.status(500).json({ error: "프로필 조회에 실패했습니다" });
   }
 };

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -6,13 +6,13 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return res.status(401).json({ error: "Unauthorized: No token provided" });
+    return res.status(401).json({ error: "인증이 필요합니다" });
   }
 
   const idToken = authHeader.split("Bearer ")[1];
 
   if (!idToken) {
-    return res.status(401).json({ error: "Unauthorized: Empty token provided" });
+    return res.status(401).json({ error: "인증이 필요합니다" });
   }
 
   try {
@@ -21,6 +21,6 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
     next();
   } catch (error) {
     logger.error({ err: error }, "Error verifying Firebase ID token");
-    return res.status(401).json({ error: "Unauthorized: Invalid token" });
+    return res.status(401).json({ error: "인증 정보가 유효하지 않습니다" });
   }
 };

--- a/src/server/middleware/rateLimit.ts
+++ b/src/server/middleware/rateLimit.ts
@@ -62,7 +62,7 @@ export const createRateLimiter = (options: RateLimitOptions) => {
       const retryAfterSeconds = Math.max(1, Math.ceil((entry.resetAt - now) / 1000));
       res.setHeader("Retry-After", String(retryAfterSeconds));
       return res.status(429).json({
-        error: `Too many ${displayName} requests. Try again in ${retryAfterSeconds} seconds.`,
+        error: `${displayName} 요청이 너무 많습니다. ${retryAfterSeconds}초 후 다시 시도해주세요.`,
       });
     }
 
@@ -88,5 +88,5 @@ const GEMINI_WINDOW_MS = parseIntEnv(process.env.GEMINI_RATE_LIMIT_WINDOW_MS, 60
 export const geminiRateLimit = createRateLimiter({
   limit: GEMINI_LIMIT,
   windowMs: GEMINI_WINDOW_MS,
-  displayName: "AI analysis",
+  displayName: "AI 분석",
 });

--- a/src/server/services/categoryService.ts
+++ b/src/server/services/categoryService.ts
@@ -5,19 +5,19 @@ import { adminDb } from "../firebaseAdmin.js";
 const ensureFamilyMembership = async (familyId: string, userId: string) => {
   const familyDoc = await adminDb.collection("familyGroups").doc(familyId).get();
   if (!familyDoc.exists) {
-    throw new Error("Family group not found");
+    throw new Error("가족 그룹을 찾을 수 없습니다");
   }
 
   const familyData = familyDoc.data();
   if (!familyData?.members.includes(userId)) {
-    throw new Error("User is not a member of this family group");
+    throw new Error("해당 가족 그룹의 멤버가 아닙니다");
   }
 };
 
 const getCategoryById = async (categoryId: string): Promise<CategoryRecord> => {
   const categoryDoc = await adminDb.collection("categories").doc(categoryId).get();
   if (!categoryDoc.exists) {
-    throw new Error("Category not found");
+    throw new Error("카테고리를 찾을 수 없습니다");
   }
 
   return {
@@ -33,11 +33,11 @@ export const createCategory = async (
 ): Promise<CategoryRecord> => {
   const trimmedName = name.trim();
   if (!trimmedName) {
-    throw new Error("Category name is required");
+    throw new Error("카테고리 이름을 입력해주세요");
   }
 
   if (trimmedName.length > 100) {
-    throw new Error("Category name must be 100 characters or fewer");
+    throw new Error("카테고리 이름은 100자 이하로 입력해주세요");
   }
 
   if (familyId) {
@@ -73,12 +73,12 @@ export const createCategory = async (
 
 export const deleteCategory = async (categoryId: string, userId: string) => {
   if (!categoryId) {
-    throw new Error("Category ID is required");
+    throw new Error("카테고리 ID가 필요합니다");
   }
 
   const category = await getCategoryById(categoryId);
   if (category.userId !== userId) {
-    throw new Error("Only the category owner can delete this category");
+    throw new Error("카테고리 삭제는 작성자만 가능합니다");
   }
 
   const tasksSnapshot = await adminDb.collection("tasks").where("categoryId", "==", categoryId).get();

--- a/src/server/services/familyService.ts
+++ b/src/server/services/familyService.ts
@@ -51,21 +51,21 @@ export const joinFamilyGroup = async (userId: string, code: string) => {
     .get();
 
   if (invitesSnapshot.empty) {
-    throw new Error("Invalid invite code");
+    throw new Error("유효하지 않은 초대 코드입니다");
   }
 
   const inviteDoc = invitesSnapshot.docs[0];
   const inviteData = inviteDoc.data();
 
   if (new Date(inviteData.expiresAt) < new Date()) {
-    throw new Error("Invite code has expired");
+    throw new Error("초대 코드가 만료되었습니다");
   }
 
   const familyRef = adminDb.collection("familyGroups").doc(inviteData.familyId);
   const familyDoc = await familyRef.get();
 
   if (!familyDoc.exists) {
-    throw new Error("Family group no longer exists");
+    throw new Error("가족 그룹이 더 이상 존재하지 않습니다");
   }
 
   const familyData = familyDoc.data();

--- a/src/server/services/taskService.ts
+++ b/src/server/services/taskService.ts
@@ -37,7 +37,7 @@ interface CategoryRecord {
 const getTaskById = async (taskId: string) => {
   const taskDoc = await adminDb.collection("tasks").doc(taskId).get();
   if (!taskDoc.exists) {
-    throw new Error("Task not found");
+    throw new Error("할 일을 찾을 수 없습니다");
   }
 
   return {
@@ -65,11 +65,11 @@ const canDeleteTask = async (task: TaskRecord, userId: string) => {
 
 const validateShoppingItems = (shoppingItems: UpdateTaskRequest["shoppingItems"]) => {
   if (!Array.isArray(shoppingItems)) {
-    throw new Error("Shopping items must be an array");
+    throw new Error("쇼핑 목록 형식이 올바르지 않습니다");
   }
 
   if (shoppingItems.length > 200) {
-    throw new Error("Shopping items must contain 200 items or fewer");
+    throw new Error("쇼핑 목록은 최대 200개까지 가능합니다");
   }
 
   for (const item of shoppingItems) {
@@ -79,15 +79,15 @@ const validateShoppingItems = (shoppingItems: UpdateTaskRequest["shoppingItems"]
       typeof item.category !== "string" ||
       typeof item.checked !== "boolean"
     ) {
-      throw new Error("Shopping items must include name, category, and checked");
+      throw new Error("쇼핑 항목에 이름, 카테고리, 체크 여부가 필요합니다");
     }
 
     if (item.name.trim().length === 0 || item.name.length > 200) {
-      throw new Error("Shopping item names must be between 1 and 200 characters");
+      throw new Error("쇼핑 항목 이름은 1~200자여야 합니다");
     }
 
     if (item.category.trim().length === 0 || item.category.length > 100) {
-      throw new Error("Shopping item categories must be between 1 and 100 characters");
+      throw new Error("쇼핑 항목 카테고리는 1~100자여야 합니다");
     }
   }
 };
@@ -95,12 +95,12 @@ const validateShoppingItems = (shoppingItems: UpdateTaskRequest["shoppingItems"]
 const ensureFamilyMembership = async (familyId: string, userId: string) => {
   const familyDoc = await adminDb.collection("familyGroups").doc(familyId).get();
   if (!familyDoc.exists) {
-    throw new Error("Family group not found");
+    throw new Error("가족 그룹을 찾을 수 없습니다");
   }
 
   const familyData = familyDoc.data();
   if (!familyData?.members.includes(userId)) {
-    throw new Error("User is not a member of this family group");
+    throw new Error("해당 가족 그룹의 멤버가 아닙니다");
   }
 };
 
@@ -139,15 +139,15 @@ export const analyzeAndCreateTask = async (
   const title = params.input.trim();
 
   if (!title) {
-    throw new Error("Task input is required");
+    throw new Error("할 일 내용을 입력해주세요");
   }
 
   if (title.length > 500) {
-    throw new Error("Task input must be 500 characters or fewer");
+    throw new Error("할 일 내용은 500자 이하로 입력해주세요");
   }
 
   if (params.familyId && typeof params.familyId !== "string") {
-    throw new Error("Family ID must be a string");
+    throw new Error("Family ID가 올바르지 않습니다");
   }
 
   if (params.familyId) {
@@ -156,7 +156,7 @@ export const analyzeAndCreateTask = async (
 
   const categories = await getCategoriesForScope(params.userId, params.familyId);
   if (categories.length === 0) {
-    throw new Error("Create at least one category before adding tasks");
+    throw new Error("할 일을 추가하려면 먼저 카테고리를 만들어주세요");
   }
 
   const analysis = await analyzeTaskWithGemini(
@@ -193,20 +193,20 @@ export const updateTask = async (
   userId: string
 ): Promise<TaskRecord> => {
   if (!taskId) {
-    throw new Error("Task ID is required");
+    throw new Error("할 일 ID가 필요합니다");
   }
 
   const allowedKeys = Object.keys(updates);
   if (allowedKeys.length === 0) {
-    throw new Error("At least one field must be provided");
+    throw new Error("수정할 항목을 입력해주세요");
   }
 
   if (allowedKeys.some((key) => !["status", "shoppingItems"].includes(key))) {
-    throw new Error("Only status and shoppingItems can be updated");
+    throw new Error("수정 가능한 항목은 상태와 쇼핑 목록입니다");
   }
 
   if (updates.status !== undefined && !["pending", "completed"].includes(updates.status)) {
-    throw new Error("Status must be pending or completed");
+    throw new Error("상태는 pending 또는 completed여야 합니다");
   }
 
   if (updates.shoppingItems !== undefined) {
@@ -216,7 +216,7 @@ export const updateTask = async (
   const task = await getTaskById(taskId);
   const canUpdate = await canUpdateTask(task, userId);
   if (!canUpdate) {
-    throw new Error("Access denied");
+    throw new Error("접근 권한이 없습니다");
   }
 
   const nextTask = {
@@ -233,13 +233,13 @@ export const updateTask = async (
 
 export const deleteTask = async (taskId: string, userId: string) => {
   if (!taskId) {
-    throw new Error("Task ID is required");
+    throw new Error("할 일 ID가 필요합니다");
   }
 
   const task = await getTaskById(taskId);
   const canDelete = await canDeleteTask(task, userId);
   if (!canDelete) {
-    throw new Error("Only the task owner can delete this task");
+    throw new Error("할 일 삭제는 작성자만 가능합니다");
   }
 
   await adminDb.collection("tasks").doc(taskId).delete();
@@ -248,29 +248,29 @@ export const deleteTask = async (taskId: string, userId: string) => {
 export const createSharedTask = async (params: CreateTaskParams) => {
   // 1. Basic Validation
   if (!params.title || params.title.trim().length === 0) {
-    throw new Error("Task title is required");
+    throw new Error("할 일 제목을 입력해주세요");
   }
 
   if (!params.categoryId) {
-    throw new Error("Category ID is required");
+    throw new Error("카테고리 ID가 필요합니다");
   }
 
   // 2. AI Data Validation
   if (typeof params.priority !== "number" || params.priority < 1 || params.priority > 5) {
-    throw new Error("Priority must be a number between 1 and 5");
+    throw new Error("우선순위는 1~5 사이의 숫자여야 합니다");
   }
 
   if (!params.aiReasoning || params.aiReasoning.trim().length === 0) {
-    throw new Error("AI reasoning is required for shared tasks");
+    throw new Error("AI 분석 결과가 필요합니다");
   }
 
   // 3. Date/Time Validation (Simple regex check)
   if (params.dueDate && !/^\d{4}-\d{2}-\d{2}$/.test(params.dueDate)) {
-    throw new Error("Invalid due date format (YYYY-MM-DD)");
+    throw new Error("날짜 형식이 올바르지 않습니다 (YYYY-MM-DD)");
   }
 
   if (params.reminderTime && !/^\d{2}:\d{2}$/.test(params.reminderTime)) {
-    throw new Error("Invalid reminder time format (HH:mm)");
+    throw new Error("시간 형식이 올바르지 않습니다 (HH:mm)");
   }
 
   // 4. Family Membership Validation (if familyId is provided)
@@ -295,11 +295,11 @@ export const getTasksByFamily = async (familyId: string, userId: string) => {
     // Verify membership
     const familyDoc = await adminDb.collection("familyGroups").doc(familyId).get();
     if (!familyDoc.exists) {
-      throw new Error("Family group not found");
+      throw new Error("가족 그룹을 찾을 수 없습니다");
     }
     const familyData = familyDoc.data();
     if (!familyData?.members.includes(userId)) {
-      throw new Error("Access denied: You are not a member of this group");
+      throw new Error("해당 가족 그룹의 멤버가 아닙니다");
     }
 
     const snapshot = await adminDb

--- a/src/server/utils/errorHandlers.ts
+++ b/src/server/utils/errorHandlers.ts
@@ -1,53 +1,9 @@
-import { adminAuth } from "../firebaseAdmin.js";
 import logger from "./logger.js";
 
-export interface FirestoreErrorInfo {
-  error: string;
-  operationType: 'create' | 'update' | 'delete' | 'list' | 'get' | 'write';
-  path: string | null;
-  authInfo: {
-    userId: string;
-    email: string;
-    emailVerified: boolean;
-    isAnonymous: boolean;
-    providerInfo: { providerId: string; displayName: string; email: string; }[];
-  }
-}
-
-export const handleFirestoreError = async (error: any, operationType: FirestoreErrorInfo['operationType'], path: string | null, userId?: string) => {
+export const handleFirestoreError = async (error: any, operationType: string, path: string | null, userId?: string) => {
   if (error.message && (error.message.includes("insufficient permissions") || error.code === 7)) {
-    const authInfo: any = {
-      userId: userId || 'unknown',
-      email: 'unknown',
-      emailVerified: false,
-      isAnonymous: true,
-      providerInfo: []
-    };
-
-    if (userId) {
-      try {
-        const user = await adminAuth.getUser(userId);
-        authInfo.email = user.email || 'unknown';
-        authInfo.emailVerified = user.emailVerified || false;
-        authInfo.isAnonymous = false;
-        authInfo.providerInfo = user.providerData.map(p => ({
-          providerId: p.providerId,
-          displayName: p.displayName || '',
-          email: p.email || ''
-        }));
-      } catch (authErr) {
-        logger.error({ err: authErr }, "Error fetching user info for error report");
-      }
-    }
-
-    const info: FirestoreErrorInfo = {
-      error: error.message,
-      operationType,
-      path,
-      authInfo
-    };
-
-    throw new Error(JSON.stringify(info));
+    logger.error({ err: error, operationType, path, userId }, "Firestore permission denied");
+    throw new Error("데이터 접근 권한이 없습니다");
   }
   throw error;
 };

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -14,7 +14,7 @@ export const apiService = {
   async getProfile() {
     const headers = await getAuthHeaders();
     const response = await fetch("/api/profile", { headers });
-    if (!response.ok) throw new Error("Failed to fetch profile");
+    if (!response.ok) throw new Error("프로필 조회에 실패했습니다");
     return response.json();
   },
 
@@ -23,17 +23,7 @@ export const apiService = {
     const response = await fetch("/api/families", { headers });
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      if (errorData.error) {
-        try {
-          const detail = JSON.parse(errorData.error);
-          if (detail.authInfo) {
-            throw new Error(`Firestore Access Denied: ${detail.operationType} on ${detail.path}. User: ${detail.authInfo.email}`);
-          }
-        } catch (e) {
-          throw new Error(errorData.error);
-        }
-      }
-      throw new Error("Failed to fetch families");
+      throw new Error(errorData.error || "가족 그룹 조회에 실패했습니다");
     }
     return response.json();
   },
@@ -45,7 +35,10 @@ export const apiService = {
       headers,
       body: JSON.stringify({ name }),
     });
-    if (!response.ok) throw new Error("Failed to create family group");
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || "가족 그룹 생성에 실패했습니다");
+    }
     return response.json();
   },
 
@@ -56,7 +49,10 @@ export const apiService = {
       headers,
       body: JSON.stringify({ familyId }),
     });
-    if (!response.ok) throw new Error("Failed to generate invite code");
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || "초대 코드 생성에 실패했습니다");
+    }
     return response.json();
   },
 
@@ -68,8 +64,8 @@ export const apiService = {
       body: JSON.stringify({ code }),
     });
     if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error || "Failed to join family group");
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.error || "가족 그룹 참여에 실패했습니다");
     }
     return response.json();
   },


### PR DESCRIPTION
## Summary

백엔드 에러 메시지 전체 한국어 번역 + M-4 (이메일 노출) 보안 수정.

## 변경 파일

컨트롤러 4개, 서비스 3개, 미들웨어 2개, errorHandlers.ts

## 주요 변경

- 사용자에게 노출되는 모든 에러 메시지 → 한국어
- rateLimit `displayName` "AI analysis" → "AI 분석" → 429 메시지: "AI 분석 요청이 너무 많습니다. N초 후 다시 시도해주세요."
- **errorHandlers.ts M-4 보안 수정**: 기존에 `throw new Error(JSON.stringify({ authInfo: { email, providerData } }))` 형태로 사용자 이메일이 에러 메시지에 포함되어 구조화 로그에 노출되었음. 이제 `logger.error()`로 컨텍스트 로깅 후 "데이터 접근 권한이 없습니다" 제네릭 메시지만 throw.
- 내부 개발자용 logger 메시지(영어)는 유지

## 테스트

- `npm run lint` 통과
- 번역 전후 에러 메시지 직접 대조 확인

Closes #42