### PR TITLE
Implement in-app account deletion flow (#18)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,20 +256,11 @@ function AppContent() {
   };
 
   const handleDeleteAccount = async () => {
-    const confirmed = window.confirm(
-      "정말 계정을 삭제하시겠습니까?\n\n" +
-      "• 모든 카테고리와 할 일이 삭제됩니다\n" +
-      "• 가족 그룹 소유자인 경우 그룹이 해산됩니다\n" +
-      "• 이 작업은 되돌릴 수 없습니다"
-    );
-    if (!confirmed) return;
-
     try {
       await apiService.deleteAccount();
       await signOut(auth);
       toast.success("계정이 삭제되었습니다.");
     } catch (error: any) {
-      console.error("Delete account error:", error);
       toast.error(error.message || "계정 삭제에 실패했습니다.");
     }
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,15 +29,16 @@ import { apiService } from './services/apiService';
 import { useNotification } from './hooks/useNotification';
 import { FamilyProvider, useFamily } from './contexts/FamilyContext';
 import { FamilySettings } from './components/FamilySettings';
-import { 
-  Plus, 
-  Trash2, 
-  CheckCircle2, 
-  Circle, 
-  BrainCircuit, 
-  LogOut, 
-  LogIn, 
-  ChevronRight, 
+import { UserSettings } from './components/UserSettings';
+import {
+  Plus,
+  Trash2,
+  CheckCircle2,
+  Circle,
+  BrainCircuit,
+  LogOut,
+  LogIn,
+  ChevronRight,
   ChevronDown,
   AlertCircle,
   Loader2,
@@ -54,7 +55,7 @@ import {
   CheckSquare,
   Users,
   Shield,
-  UserX
+  Settings
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Toaster, toast } from 'sonner';
@@ -130,6 +131,7 @@ function AppContent() {
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const [notifiedTasks, setNotifiedTasks] = useState<Set<string>>(new Set());
   const [showFamilySettings, setShowFamilySettings] = useState(false);
+  const [showUserSettings, setShowUserSettings] = useState(false);
   const [selectedFamilyId, setSelectedFamilyId] = useState<string | null>(null);
 
   const { families } = useFamily();
@@ -571,18 +573,11 @@ function AppContent() {
             <p className="text-sm font-medium">{user.displayName}</p>
           </div>
           <button
-            onClick={handleDeleteAccount}
-            className="p-2 hover:bg-red-100 rounded-full transition-colors"
-            title="계정 삭제"
-          >
-            <UserX className="w-5 h-5 text-stone-400 hover:text-red-500 transition-colors" />
-          </button>
-          <button
-            onClick={handleLogout}
+            onClick={() => setShowUserSettings(true)}
             className="p-2 hover:bg-stone-200 rounded-full transition-colors"
-            title="로그아웃"
+            title="설정"
           >
-            <LogOut className="w-5 h-5 text-stone-500" />
+            <Settings className="w-5 h-5 text-stone-500" />
           </button>
         </div>
       </header>
@@ -895,6 +890,17 @@ function AppContent() {
       <AnimatePresence>
         {showFamilySettings && (
           <FamilySettings onClose={() => setShowFamilySettings(false)} />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {showUserSettings && (
+          <UserSettings
+            user={user}
+            onClose={() => setShowUserSettings(false)}
+            onLogout={handleLogout}
+            onDeleteAccount={handleDeleteAccount}
+          />
         )}
       </AnimatePresence>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -549,29 +549,6 @@ function AppContent() {
               Timeline
             </button>
           </div>
-          <button 
-            onClick={toggleNotifications}
-            className={cn(
-              "p-2 rounded-full transition-all relative",
-              notificationsEnabled ? "bg-stone-900 text-white" : "bg-stone-200 text-stone-500 hover:bg-stone-300"
-            )}
-            title={notificationsEnabled ? "알림 끄기" : "알림 켜기"}
-          >
-            <motion.div
-              initial={false}
-              animate={{ rotate: notificationsEnabled ? [0, -10, 10, -10, 10, 0] : 0 }}
-              transition={{ duration: 0.5 }}
-            >
-              {notificationsEnabled ? <Bell className="w-5 h-5" /> : <BellOff className="w-5 h-5" />}
-            </motion.div>
-            {notificationsEnabled && (
-              <span className="absolute top-0 right-0 w-2 h-2 bg-red-500 rounded-full border border-stone-900" />
-            )}
-          </button>
-          <div className="hidden sm:block text-right">
-            <p className="text-xs text-stone-400 uppercase tracking-widest font-bold">User</p>
-            <p className="text-sm font-medium">{user.displayName}</p>
-          </div>
           <button
             onClick={() => setShowUserSettings(true)}
             className="p-2 hover:bg-stone-200 rounded-full transition-colors"
@@ -900,6 +877,8 @@ function AppContent() {
             onClose={() => setShowUserSettings(false)}
             onLogout={handleLogout}
             onDeleteAccount={handleDeleteAccount}
+            notificationsEnabled={notificationsEnabled}
+            onToggleNotifications={toggleNotifications}
           />
         )}
       </AnimatePresence>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   deleteTask as deleteTaskOnServer,
   updateTask as updateTaskOnServer,
 } from './services/taskService';
+import { apiService } from './services/apiService';
 import { useNotification } from './hooks/useNotification';
 import { FamilyProvider, useFamily } from './contexts/FamilyContext';
 import { FamilySettings } from './components/FamilySettings';
@@ -52,7 +53,8 @@ import {
   LayoutList,
   CheckSquare,
   Users,
-  Shield
+  Shield,
+  UserX
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Toaster, toast } from 'sonner';
@@ -248,6 +250,25 @@ function AppContent() {
     } catch (error) {
       console.error("Logout error:", error);
       toast.error("로그아웃에 실패했습니다.");
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    const confirmed = window.confirm(
+      "정말 계정을 삭제하시겠습니까?\n\n" +
+      "• 모든 카테고리와 할 일이 삭제됩니다\n" +
+      "• 가족 그룹 소유자인 경우 그룹이 해산됩니다\n" +
+      "• 이 작업은 되돌릴 수 없습니다"
+    );
+    if (!confirmed) return;
+
+    try {
+      await apiService.deleteAccount();
+      await signOut(auth);
+      toast.success("계정이 삭제되었습니다.");
+    } catch (error: any) {
+      console.error("Delete account error:", error);
+      toast.error(error.message || "계정 삭제에 실패했습니다.");
     }
   };
 
@@ -549,7 +570,14 @@ function AppContent() {
             <p className="text-xs text-stone-400 uppercase tracking-widest font-bold">User</p>
             <p className="text-sm font-medium">{user.displayName}</p>
           </div>
-          <button 
+          <button
+            onClick={handleDeleteAccount}
+            className="p-2 hover:bg-red-100 rounded-full transition-colors"
+            title="계정 삭제"
+          >
+            <UserX className="w-5 h-5 text-stone-400 hover:text-red-500 transition-colors" />
+          </button>
+          <button
             onClick={handleLogout}
             className="p-2 hover:bg-stone-200 rounded-full transition-colors"
             title="로그아웃"

--- a/src/components/FamilySettings.tsx
+++ b/src/components/FamilySettings.tsx
@@ -11,7 +11,8 @@ import {
   User as UserIcon,
   Loader2
 } from "lucide-react";
-import { motion, AnimatePresence } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
+import { Modal } from "./Modal.js";
 import { toast } from "sonner";
 import { auth } from "../firebase.js";
 
@@ -69,17 +70,7 @@ export const FamilySettings: React.FC<FamilySettingsProps> = ({ onClose }) => {
   };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.95 }}
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-stone-900/40 backdrop-blur-sm"
-      onClick={onClose}
-    >
-      <div 
-        className="bg-white w-full max-w-2xl rounded-3xl shadow-2xl overflow-hidden flex flex-col max-h-[80vh]"
-        onClick={e => e.stopPropagation()}
-      >
+    <Modal onClose={onClose} maxWidth="max-w-2xl">
         <div className="p-6 border-b border-stone-100 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-stone-100 rounded-xl">
@@ -231,7 +222,6 @@ export const FamilySettings: React.FC<FamilySettingsProps> = ({ onClose }) => {
             )}
           </section>
         </div>
-      </div>
-    </motion.div>
+    </Modal>
   );
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,20 +1,21 @@
 import React from "react";
 import { motion } from "motion/react";
 
+type MaxWidth = "max-w-sm" | "max-w-md" | "max-w-lg" | "max-w-xl" | "max-w-2xl";
+type MaxHeight = "max-h-[80vh]" | "max-h-[85vh]" | "max-h-[90vh]";
+
 interface ModalProps {
   onClose: () => void;
   children: React.ReactNode;
-  maxWidth?: string;
+  maxWidth?: MaxWidth;
+  maxHeight?: MaxHeight;
 }
 
-/**
- * Shared slide-in modal overlay used by FamilySettings and UserSettings.
- * Wrap the usage site with <AnimatePresence> to get exit animations.
- */
 export const Modal: React.FC<ModalProps> = ({
   onClose,
   children,
   maxWidth = "max-w-2xl",
+  maxHeight = "max-h-[85vh]",
 }) => {
   return (
     <motion.div
@@ -25,7 +26,7 @@ export const Modal: React.FC<ModalProps> = ({
       onClick={onClose}
     >
       <motion.div
-        className={`bg-white w-full ${maxWidth} rounded-3xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]`}
+        className={`bg-white w-full ${maxWidth} rounded-3xl shadow-2xl overflow-hidden flex flex-col ${maxHeight}`}
         initial={{ opacity: 0, scale: 0.95, y: 10 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.95, y: 10 }}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { motion } from "motion/react";
+
+interface ModalProps {
+  onClose: () => void;
+  children: React.ReactNode;
+  maxWidth?: string;
+}
+
+/**
+ * Shared slide-in modal overlay used by FamilySettings and UserSettings.
+ * Wrap the usage site with <AnimatePresence> to get exit animations.
+ */
+export const Modal: React.FC<ModalProps> = ({
+  onClose,
+  children,
+  maxWidth = "max-w-2xl",
+}) => {
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-stone-900/40 backdrop-blur-sm"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      onClick={onClose}
+    >
+      <motion.div
+        className={`bg-white w-full ${maxWidth} rounded-3xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]`}
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        transition={{ type: "spring", damping: 25, stiffness: 300 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </motion.div>
+    </motion.div>
+  );
+};

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from "react";
+import {
+  X,
+  LogOut,
+  UserX,
+  Settings,
+  User as UserIcon,
+  Mail,
+  AlertTriangle,
+} from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
+import { User } from "firebase/auth";
+
+interface UserSettingsProps {
+  user: User;
+  onClose: () => void;
+  onLogout: () => Promise<void>;
+  onDeleteAccount: () => Promise<void>;
+}
+
+export const UserSettings: React.FC<UserSettingsProps> = ({
+  user,
+  onClose,
+  onLogout,
+  onDeleteAccount,
+}) => {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDeleteConfirm = async () => {
+    setIsDeleting(true);
+    try {
+      await onDeleteAccount();
+    } finally {
+      setIsDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="fixed inset-0 bg-black/40 z-50 flex items-end sm:items-center justify-center p-4"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={onClose}
+      >
+        <motion.div
+          className="bg-white w-full max-w-md rounded-3xl shadow-2xl overflow-hidden flex flex-col max-h-[80vh]"
+          initial={{ y: 40, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 40, opacity: 0 }}
+          transition={{ type: "spring", damping: 25, stiffness: 300 }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="p-6 border-b border-stone-100 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-stone-100 rounded-xl">
+                <Settings className="w-6 h-6 text-stone-900" />
+              </div>
+              <div>
+                <h2 className="text-xl font-serif italic text-stone-900">설정</h2>
+                <p className="text-xs text-stone-400 uppercase tracking-widest font-bold">Settings</p>
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-stone-100 rounded-full transition-colors"
+            >
+              <X className="w-6 h-6 text-stone-400" />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-6 space-y-6">
+            {/* Profile */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-bold text-stone-400 uppercase tracking-widest">계정 정보</h3>
+              <div className="bg-stone-50 rounded-2xl p-4 space-y-2">
+                {user.displayName && (
+                  <div className="flex items-center gap-3 text-sm text-stone-700">
+                    <UserIcon className="w-4 h-4 text-stone-400 shrink-0" />
+                    <span>{user.displayName}</span>
+                  </div>
+                )}
+                {user.email && (
+                  <div className="flex items-center gap-3 text-sm text-stone-500">
+                    <Mail className="w-4 h-4 text-stone-400 shrink-0" />
+                    <span>{user.email}</span>
+                  </div>
+                )}
+              </div>
+            </section>
+
+            {/* Actions */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-bold text-stone-400 uppercase tracking-widest">계정 관리</h3>
+              <button
+                onClick={async () => { await onLogout(); onClose(); }}
+                className="w-full flex items-center gap-3 p-4 bg-stone-50 hover:bg-stone-100 rounded-2xl transition-colors text-left"
+              >
+                <LogOut className="w-5 h-5 text-stone-500" />
+                <div>
+                  <p className="text-sm font-semibold text-stone-700">로그아웃</p>
+                  <p className="text-xs text-stone-400">현재 기기에서 로그아웃합니다</p>
+                </div>
+              </button>
+            </section>
+
+            {/* Danger zone */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-bold text-red-400 uppercase tracking-widest">위험 구역</h3>
+              {!showDeleteConfirm ? (
+                <button
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="w-full flex items-center gap-3 p-4 bg-red-50 hover:bg-red-100 rounded-2xl transition-colors text-left border border-red-100"
+                >
+                  <UserX className="w-5 h-5 text-red-400" />
+                  <div>
+                    <p className="text-sm font-semibold text-red-600">계정 삭제</p>
+                    <p className="text-xs text-red-400">모든 데이터가 영구 삭제됩니다</p>
+                  </div>
+                </button>
+              ) : (
+                <div className="bg-red-50 border border-red-200 rounded-2xl p-4 space-y-4">
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+                    <div className="space-y-1 text-sm text-red-700">
+                      <p className="font-semibold">정말 삭제하시겠습니까?</p>
+                      <ul className="text-xs text-red-500 space-y-1 list-disc list-inside">
+                        <li>모든 카테고리와 할 일이 삭제됩니다</li>
+                        <li>소유한 가족 그룹이 해산됩니다</li>
+                        <li>이 작업은 되돌릴 수 없습니다</li>
+                      </ul>
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setShowDeleteConfirm(false)}
+                      className="flex-1 py-2 px-3 bg-white border border-stone-200 rounded-xl text-sm font-medium text-stone-600 hover:bg-stone-50 transition-colors"
+                    >
+                      취소
+                    </button>
+                    <button
+                      onClick={handleDeleteConfirm}
+                      disabled={isDeleting}
+                      className="flex-1 py-2 px-3 bg-red-500 hover:bg-red-600 text-white rounded-xl text-sm font-semibold transition-colors disabled:opacity-50"
+                    >
+                      {isDeleting ? "삭제 중..." : "삭제 확인"}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </section>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -10,8 +10,8 @@ import {
   Bell,
   BellOff,
 } from "lucide-react";
-import { motion, AnimatePresence } from "motion/react";
 import { User } from "firebase/auth";
+import { Modal } from "./Modal.js";
 
 interface UserSettingsProps {
   user: User;
@@ -44,22 +44,7 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
   };
 
   return (
-    <AnimatePresence>
-      <motion.div
-        className="fixed inset-0 bg-black/40 z-50 flex items-end sm:items-center justify-center p-4"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        onClick={onClose}
-      >
-        <motion.div
-          className="bg-white w-full max-w-md rounded-3xl shadow-2xl overflow-hidden flex flex-col max-h-[80vh]"
-          initial={{ y: 40, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          exit={{ y: 40, opacity: 0 }}
-          transition={{ type: "spring", damping: 25, stiffness: 300 }}
-          onClick={(e) => e.stopPropagation()}
-        >
+    <Modal onClose={onClose} maxWidth="max-w-md">
           {/* Header */}
           <div className="p-6 border-b border-stone-100 flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -185,8 +170,6 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
               )}
             </section>
           </div>
-        </motion.div>
-      </motion.div>
-    </AnimatePresence>
+    </Modal>
   );
 };

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -9,6 +9,7 @@ import {
   AlertTriangle,
   Bell,
   BellOff,
+  Loader2,
 } from "lucide-react";
 import { User } from "firebase/auth";
 import { Modal } from "./Modal.js";
@@ -32,6 +33,7 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
 }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const handleDeleteConfirm = async () => {
     setIsDeleting(true);
@@ -44,7 +46,7 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
   };
 
   return (
-    <Modal onClose={onClose} maxWidth="max-w-md">
+    <Modal onClose={onClose} maxWidth="max-w-md" maxHeight="max-h-[80vh]">
           {/* Header */}
           <div className="p-6 border-b border-stone-100 flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -113,10 +115,14 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
             <section className="space-y-3">
               <h3 className="text-xs font-bold text-stone-400 uppercase tracking-widest">계정 관리</h3>
               <button
-                onClick={async () => { await onLogout(); onClose(); }}
-                className="w-full flex items-center gap-3 p-4 bg-stone-50 hover:bg-stone-100 rounded-2xl transition-colors text-left"
+                onClick={async () => {
+                  setIsLoggingOut(true);
+                  try { await onLogout(); onClose(); } finally { setIsLoggingOut(false); }
+                }}
+                disabled={isLoggingOut}
+                className="w-full flex items-center gap-3 p-4 bg-stone-50 hover:bg-stone-100 rounded-2xl transition-colors text-left disabled:opacity-50"
               >
-                <LogOut className="w-5 h-5 text-stone-500" />
+                {isLoggingOut ? <Loader2 className="w-5 h-5 text-stone-400 animate-spin" /> : <LogOut className="w-5 h-5 text-stone-500" />}
                 <div>
                   <p className="text-sm font-semibold text-stone-700">로그아웃</p>
                   <p className="text-xs text-stone-400">현재 기기에서 로그아웃합니다</p>

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -7,6 +7,8 @@ import {
   User as UserIcon,
   Mail,
   AlertTriangle,
+  Bell,
+  BellOff,
 } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
 import { User } from "firebase/auth";
@@ -16,6 +18,8 @@ interface UserSettingsProps {
   onClose: () => void;
   onLogout: () => Promise<void>;
   onDeleteAccount: () => Promise<void>;
+  notificationsEnabled: boolean;
+  onToggleNotifications: () => Promise<void>;
 }
 
 export const UserSettings: React.FC<UserSettingsProps> = ({
@@ -23,6 +27,8 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
   onClose,
   onLogout,
   onDeleteAccount,
+  notificationsEnabled,
+  onToggleNotifications,
 }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -93,7 +99,32 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
               </div>
             </section>
 
-            {/* Actions */}
+            {/* Notifications */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-bold text-stone-400 uppercase tracking-widest">알림</h3>
+              <button
+                onClick={onToggleNotifications}
+                className="w-full flex items-center justify-between p-4 bg-stone-50 hover:bg-stone-100 rounded-2xl transition-colors text-left"
+              >
+                <div className="flex items-center gap-3">
+                  {notificationsEnabled
+                    ? <Bell className="w-5 h-5 text-stone-900" />
+                    : <BellOff className="w-5 h-5 text-stone-400" />
+                  }
+                  <div>
+                    <p className="text-sm font-semibold text-stone-700">할 일 알림</p>
+                    <p className="text-xs text-stone-400">
+                      {notificationsEnabled ? "알림이 켜져 있습니다" : "알림이 꺼져 있습니다"}
+                    </p>
+                  </div>
+                </div>
+                <div className={`w-10 h-6 rounded-full transition-colors relative ${notificationsEnabled ? "bg-stone-900" : "bg-stone-200"}`}>
+                  <div className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${notificationsEnabled ? "translate-x-5" : "translate-x-1"}`} />
+                </div>
+              </button>
+            </section>
+
+            {/* Account actions */}
             <section className="space-y-3">
               <h3 className="text-xs font-bold text-stone-400 uppercase tracking-widest">계정 관리</h3>
               <button

--- a/src/server/controllers/userController.ts
+++ b/src/server/controllers/userController.ts
@@ -1,4 +1,6 @@
 import { Request, Response } from "express";
+import { deleteUserAccount } from "../services/userService.js";
+import logger from "../utils/logger.js";
 
 export const getProfile = async (req: Request, res: Response) => {
   try {
@@ -12,5 +14,16 @@ export const getProfile = async (req: Request, res: Response) => {
     });
   } catch (error) {
     res.status(500).json({ error: "프로필 조회에 실패했습니다" });
+  }
+};
+
+export const deleteAccount = async (req: Request, res: Response) => {
+  const user = req.user;
+  try {
+    await deleteUserAccount(user.uid);
+    res.status(204).send();
+  } catch (error: any) {
+    logger.error({ err: error, uid: user.uid }, "Error deleting account");
+    res.status(500).json({ error: error.message || "계정 삭제에 실패했습니다" });
   }
 };

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -3,7 +3,7 @@ import {
   createCategory,
   deleteCategory,
 } from "../controllers/categoryController.js";
-import { getProfile } from "../controllers/userController.js";
+import { getProfile, deleteAccount } from "../controllers/userController.js";
 import {
   createFamily,
   generateInvite,
@@ -24,6 +24,7 @@ const router = Router();
 
 // User routes
 router.get("/profile", authMiddleware, getProfile);
+router.delete("/account", authMiddleware, deleteAccount);
 
 // Family routes
 router.get("/families", authMiddleware, getMyFamilies);

--- a/src/server/services/userService.ts
+++ b/src/server/services/userService.ts
@@ -1,5 +1,17 @@
 import { adminAuth, adminDb } from "../firebaseAdmin.js";
 import logger from "../utils/logger.js";
+import type { DocumentReference } from "firebase-admin/firestore";
+
+const BATCH_LIMIT = 499;
+
+async function deleteInBatches(refs: DocumentReference[]): Promise<void> {
+  const db = adminDb;
+  for (let i = 0; i < refs.length; i += BATCH_LIMIT) {
+    const batch = db.batch();
+    refs.slice(i, i + BATCH_LIMIT).forEach((ref) => batch.delete(ref));
+    await batch.commit();
+  }
+}
 
 export const deleteUserAccount = async (userId: string): Promise<void> => {
   const db = adminDb;
@@ -13,15 +25,11 @@ export const deleteUserAccount = async (userId: string): Promise<void> => {
   for (const familyDoc of ownedFamilies.docs) {
     const familyId = familyDoc.id;
 
-    // Delete all invites for this family
     const invites = await db
       .collection("invites")
       .where("familyId", "==", familyId)
       .get();
-    const batch = db.batch();
-    invites.docs.forEach((d) => batch.delete(d.ref));
-    batch.delete(familyDoc.ref);
-    await batch.commit();
+    await deleteInBatches([...invites.docs.map((d) => d.ref), familyDoc.ref]);
 
     logger.info({ familyId, userId }, "Deleted owned family group");
   }
@@ -46,20 +54,14 @@ export const deleteUserAccount = async (userId: string): Promise<void> => {
     .collection("categories")
     .where("userId", "==", userId)
     .get();
-
-  const catBatch = db.batch();
-  categories.docs.forEach((d) => catBatch.delete(d.ref));
-  await catBatch.commit();
+  await deleteInBatches(categories.docs.map((d) => d.ref));
 
   // 4. Delete all tasks owned by user
   const tasks = await db
     .collection("tasks")
     .where("userId", "==", userId)
     .get();
-
-  const taskBatch = db.batch();
-  tasks.docs.forEach((d) => taskBatch.delete(d.ref));
-  await taskBatch.commit();
+  await deleteInBatches(tasks.docs.map((d) => d.ref));
 
   // 5. Delete Firebase Auth user last so the earlier steps still have auth context
   await adminAuth.deleteUser(userId);

--- a/src/server/services/userService.ts
+++ b/src/server/services/userService.ts
@@ -1,0 +1,68 @@
+import { adminAuth, adminDb } from "../firebaseAdmin.js";
+import logger from "../utils/logger.js";
+
+export const deleteUserAccount = async (userId: string): Promise<void> => {
+  const db = adminDb;
+
+  // 1. Family groups where this user is the owner → delete entirely
+  const ownedFamilies = await db
+    .collection("familyGroups")
+    .where("ownerId", "==", userId)
+    .get();
+
+  for (const familyDoc of ownedFamilies.docs) {
+    const familyId = familyDoc.id;
+
+    // Delete all invites for this family
+    const invites = await db
+      .collection("invites")
+      .where("familyId", "==", familyId)
+      .get();
+    const batch = db.batch();
+    invites.docs.forEach((d) => batch.delete(d.ref));
+    batch.delete(familyDoc.ref);
+    await batch.commit();
+
+    logger.info({ familyId, userId }, "Deleted owned family group");
+  }
+
+  // 2. Family groups where this user is a member (but not owner) → remove from members
+  const memberFamilies = await db
+    .collection("familyGroups")
+    .where("members", "array-contains", userId)
+    .get();
+
+  for (const familyDoc of memberFamilies.docs) {
+    const data = familyDoc.data();
+    if (data.ownerId !== userId) {
+      await familyDoc.ref.update({
+        members: data.members.filter((m: string) => m !== userId),
+      });
+    }
+  }
+
+  // 3. Delete all categories owned by user
+  const categories = await db
+    .collection("categories")
+    .where("userId", "==", userId)
+    .get();
+
+  const catBatch = db.batch();
+  categories.docs.forEach((d) => catBatch.delete(d.ref));
+  await catBatch.commit();
+
+  // 4. Delete all tasks owned by user
+  const tasks = await db
+    .collection("tasks")
+    .where("userId", "==", userId)
+    .get();
+
+  const taskBatch = db.batch();
+  tasks.docs.forEach((d) => taskBatch.delete(d.ref));
+  await taskBatch.commit();
+
+  // 5. Delete Firebase Auth user last so the earlier steps still have auth context
+  await adminAuth.deleteUser(userId);
+
+  logger.info({ userId }, "User account deleted");
+};

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -56,6 +56,18 @@ export const apiService = {
     return response.json();
   },
 
+  async deleteAccount() {
+    const headers = await getAuthHeaders();
+    const response = await fetch("/api/account", {
+      method: "DELETE",
+      headers,
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || "계정 삭제에 실패했습니다");
+    }
+  },
+
   async joinFamily(code: string) {
     const headers = await getAuthHeaders();
     const response = await fetch("/api/family/join", {


### PR DESCRIPTION
## Summary

App Store Guideline 5.1.1(v) 준수를 위한 인앱 계정 삭제 기능 구현.

## 변경

### 백엔드 `DELETE /api/account`

`src/server/services/userService.ts` (신규) — `deleteUserAccount()` 순서:
1. 소유한 가족 그룹 + 해당 초대 코드 삭제
2. 멤버로만 참여 중인 가족 그룹에서 제거
3. 사용자 카테고리 전체 삭제
4. 사용자 할 일 전체 삭제
5. Firebase Auth 계정 삭제 (마지막 — 앞 단계들이 인증 컨텍스트 필요)

### 프론트엔드

- `apiService.deleteAccount()` 추가
- `handleDeleteAccount()` — `window.confirm`으로 결과 목록 안내 → API 호출 → `signOut`
- 헤더에 `UserX` 아이콘 버튼 (로그아웃 버튼 왼쪽): 기본 stone-400, hover시 red-500으로 파괴적 액션 표시

## 확인 다이얼로그 메시지

```
정말 계정을 삭제하시겠습니까?

• 모든 카테고리와 할 일이 삭제됩니다
• 가족 그룹 소유자인 경우 그룹이 해산됩니다
• 이 작업은 되돌릴 수 없습니다
```

## 테스트 플랜

- [ ] 계정 삭제 버튼 클릭 → confirm 다이얼로그 표시
- [ ] 취소 → 아무것도 변경되지 않음
- [ ] 확인 → 데이터 삭제 + 로그아웃 + "계정이 삭제되었습니다" 토스트
- [ ] Firebase Console에서 Auth 계정 및 Firestore 데이터 삭제 확인
- [ ] 가족 그룹 소유자 계정 삭제 시 그룹 해산 확인

Closes #18