### PR TITLE
Add privacy policy and terms of service pages (#19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.14.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "uuid": "^14.0.0",
@@ -11723,6 +11724,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -12169,6 +12221,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.14.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "uuid": "^14.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import { PrivacyPolicy } from './components/PrivacyPolicy';
+import { TermsOfService } from './components/TermsOfService';
 import { 
   GoogleAuthProvider, 
   signInWithPopup, 
@@ -111,9 +114,15 @@ interface Task {
 
 export default function App() {
   return (
-    <FamilyProvider>
-      <AppContent />
-    </FamilyProvider>
+    <Routes>
+      <Route path="/privacy" element={<PrivacyPolicy />} />
+      <Route path="/terms" element={<TermsOfService />} />
+      <Route path="/*" element={
+        <FamilyProvider>
+          <AppContent />
+        </FamilyProvider>
+      } />
+    </Routes>
   );
 }
 
@@ -852,6 +861,8 @@ function AppContent() {
             <div className="w-2 h-2 rounded-full bg-blue-500" />
             Cloud Synced
           </span>
+          <Link to="/privacy" className="hover:text-stone-600 transition-colors">Privacy</Link>
+          <Link to="/terms" className="hover:text-stone-600 transition-colors">Terms</Link>
         </div>
       </footer>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -851,7 +851,7 @@ function AppContent() {
 
       {/* Footer Info */}
       <footer className="max-w-4xl mx-auto px-6 py-12 border-t border-stone-200 flex flex-col sm:flex-row items-center justify-between gap-4 text-stone-400 text-xs uppercase tracking-widest font-bold">
-        <p>© 2026 AI Task Organizer</p>
+        <p>© 2026 Dada Task Organizer</p>
         <div className="flex items-center gap-6">
           <span className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full bg-green-500" />

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -2,14 +2,20 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 
+const CONTACT_EMAIL = "jjakmi@gmail.com";
+
 export const PrivacyPolicy: React.FC = () => {
   const navigate = useNavigate();
+  const handleBack = () => {
+    if ((window.history.state?.idx ?? 0) > 0) navigate(-1);
+    else navigate("/");
+  };
 
   return (
     <div className="min-h-screen bg-stone-50">
       <div className="max-w-2xl mx-auto px-6 py-12">
         <button
-          onClick={() => navigate(-1)}
+          onClick={handleBack}
           className="flex items-center gap-2 text-sm text-stone-500 hover:text-stone-900 transition-colors mb-8"
         >
           <ArrowLeft className="w-4 h-4" />
@@ -19,7 +25,7 @@ export const PrivacyPolicy: React.FC = () => {
         <h1 className="text-3xl font-serif italic text-stone-900 mb-2">개인정보처리방침</h1>
         <p className="text-xs text-stone-400 uppercase tracking-widest font-bold mb-10">Privacy Policy</p>
 
-        <div className="prose prose-stone max-w-none space-y-8 text-sm text-stone-700 leading-relaxed">
+        <div className="space-y-8 text-sm text-stone-700 leading-relaxed">
           <section>
             <p className="text-stone-500">최종 업데이트: 2026년 5월 2일</p>
           </section>
@@ -74,7 +80,7 @@ export const PrivacyPolicy: React.FC = () => {
           <section className="space-y-3">
             <h2 className="text-base font-bold text-stone-900">6. 개인정보 보호책임자</h2>
             <p>개인정보 관련 문의는 아래 이메일로 연락하시기 바랍니다:</p>
-            <p className="font-mono text-stone-600">jjakmi@gmail.com</p>
+            <p className="font-mono text-stone-600">{CONTACT_EMAIL}</p>
           </section>
 
           <section className="space-y-3">

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+
+export const PrivacyPolicy: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <div className="max-w-2xl mx-auto px-6 py-12">
+        <button
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-2 text-sm text-stone-500 hover:text-stone-900 transition-colors mb-8"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          뒤로 가기
+        </button>
+
+        <h1 className="text-3xl font-serif italic text-stone-900 mb-2">개인정보처리방침</h1>
+        <p className="text-xs text-stone-400 uppercase tracking-widest font-bold mb-10">Privacy Policy</p>
+
+        <div className="prose prose-stone max-w-none space-y-8 text-sm text-stone-700 leading-relaxed">
+          <section>
+            <p className="text-stone-500">최종 업데이트: 2026년 5월 2일</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">1. 수집하는 개인정보</h2>
+            <p>Dada Task Organizer(이하 "서비스")는 다음과 같은 정보를 수집합니다:</p>
+            <ul className="list-disc list-inside space-y-1 text-stone-600">
+              <li><strong>계정 정보:</strong> 이메일 주소, 이름 (Google 로그인 시 제공)</li>
+              <li><strong>서비스 이용 데이터:</strong> 카테고리, 할 일(태스크), 마감일 등 사용자가 직접 입력한 데이터</li>
+              <li><strong>가족 그룹 정보:</strong> 그룹 이름, 구성원 정보</li>
+            </ul>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">2. 개인정보 수집 및 이용 목적</h2>
+            <ul className="list-disc list-inside space-y-1 text-stone-600">
+              <li>서비스 제공 및 운영</li>
+              <li>사용자 인증 및 계정 관리</li>
+              <li>AI 기반 태스크 분석 기능 제공 (Gemini API 활용)</li>
+              <li>가족 공유 기능 제공</li>
+              <li>서비스 품질 개선</li>
+            </ul>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">3. 개인정보 보유 및 이용 기간</h2>
+            <p>수집된 개인정보는 서비스 이용 기간 동안 보유합니다. 계정 삭제 시 모든 개인정보 및 서비스 이용 데이터는 즉시 삭제됩니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">4. 제3자 서비스</h2>
+            <p>서비스는 다음 제3자 서비스를 이용합니다:</p>
+            <ul className="list-disc list-inside space-y-1 text-stone-600">
+              <li><strong>Firebase (Google):</strong> 인증 및 데이터 저장</li>
+              <li><strong>Gemini API (Google):</strong> AI 태스크 분석</li>
+              <li><strong>Google Cloud:</strong> 서버 호스팅</li>
+            </ul>
+            <p className="text-stone-500 text-xs">각 서비스의 개인정보처리방침은 해당 서비스 공식 사이트를 참고하시기 바랍니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">5. 사용자의 권리</h2>
+            <p>사용자는 다음 권리를 가집니다:</p>
+            <ul className="list-disc list-inside space-y-1 text-stone-600">
+              <li>개인정보 열람, 수정, 삭제 요청</li>
+              <li>계정 삭제를 통한 모든 데이터 삭제</li>
+              <li>개인정보 처리 동의 철회</li>
+            </ul>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">6. 개인정보 보호책임자</h2>
+            <p>개인정보 관련 문의는 아래 이메일로 연락하시기 바랍니다:</p>
+            <p className="font-mono text-stone-600">jjakmi@gmail.com</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">7. 방침 변경</h2>
+            <p>본 방침이 변경될 경우 서비스 내 공지 또는 이메일을 통해 사전 고지합니다.</p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+
+export const TermsOfService: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <div className="max-w-2xl mx-auto px-6 py-12">
+        <button
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-2 text-sm text-stone-500 hover:text-stone-900 transition-colors mb-8"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          뒤로 가기
+        </button>
+
+        <h1 className="text-3xl font-serif italic text-stone-900 mb-2">이용약관</h1>
+        <p className="text-xs text-stone-400 uppercase tracking-widest font-bold mb-10">Terms of Service</p>
+
+        <div className="prose prose-stone max-w-none space-y-8 text-sm text-stone-700 leading-relaxed">
+          <section>
+            <p className="text-stone-500">최종 업데이트: 2026년 5월 2일</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">1. 서비스 개요</h2>
+            <p>Dada Task Organizer(이하 "서비스")는 개인 및 가족 단위의 태스크 관리를 위한 웹 애플리케이션입니다. 서비스를 이용함으로써 본 약관에 동의하는 것으로 간주합니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">2. 이용 자격</h2>
+            <ul className="list-disc list-inside space-y-1 text-stone-600">
+              <li>Google 계정을 보유한 만 14세 이상인 자</li>
+              <li>본 약관에 동의한 자</li>
+            </ul>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">3. 서비스 이용 규칙</h2>
+            <p>사용자는 다음 행위를 하여서는 안 됩니다:</p>
+            <ul className="list-disc list-inside space-y-1 text-stone-600">
+              <li>타인의 계정을 무단으로 사용하는 행위</li>
+              <li>서비스의 정상적인 운영을 방해하는 행위</li>
+              <li>불법적인 목적으로 서비스를 이용하는 행위</li>
+              <li>타인의 개인정보를 수집하거나 악용하는 행위</li>
+            </ul>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">4. AI 기능 관련</h2>
+            <p>서비스는 Gemini AI를 활용한 태스크 분석 기능을 제공합니다. AI 분석 결과는 참고용이며, 서비스 제공자는 AI 결과의 정확성에 대해 보증하지 않습니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">5. 서비스 변경 및 중단</h2>
+            <p>서비스 제공자는 사전 공지 후 서비스의 내용을 변경하거나 중단할 수 있습니다. 불가피한 사정이 있는 경우 사전 공지 없이 서비스가 중단될 수 있습니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">6. 책임의 한계</h2>
+            <p>서비스 제공자는 천재지변, 네트워크 장애 등 불가항력적 사유로 인한 서비스 중단에 대해 책임을 지지 않습니다. 사용자가 서비스에 등록한 데이터의 백업은 사용자 본인의 책임입니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">7. 계정 삭제</h2>
+            <p>사용자는 언제든지 설정 화면을 통해 계정을 삭제할 수 있으며, 삭제 시 모든 데이터는 즉시 영구 삭제됩니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">8. 준거법</h2>
+            <p>본 약관은 대한민국 법률에 따라 해석되며, 분쟁 발생 시 관할 법원은 서울중앙지방법원으로 합니다.</p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-base font-bold text-stone-900">9. 문의</h2>
+            <p className="font-mono text-stone-600">jjakmi@gmail.com</p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -2,14 +2,20 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 
+const CONTACT_EMAIL = "jjakmi@gmail.com";
+
 export const TermsOfService: React.FC = () => {
   const navigate = useNavigate();
+  const handleBack = () => {
+    if ((window.history.state?.idx ?? 0) > 0) navigate(-1);
+    else navigate("/");
+  };
 
   return (
     <div className="min-h-screen bg-stone-50">
       <div className="max-w-2xl mx-auto px-6 py-12">
         <button
-          onClick={() => navigate(-1)}
+          onClick={handleBack}
           className="flex items-center gap-2 text-sm text-stone-500 hover:text-stone-900 transition-colors mb-8"
         >
           <ArrowLeft className="w-4 h-4" />
@@ -19,7 +25,7 @@ export const TermsOfService: React.FC = () => {
         <h1 className="text-3xl font-serif italic text-stone-900 mb-2">이용약관</h1>
         <p className="text-xs text-stone-400 uppercase tracking-widest font-bold mb-10">Terms of Service</p>
 
-        <div className="prose prose-stone max-w-none space-y-8 text-sm text-stone-700 leading-relaxed">
+        <div className="space-y-8 text-sm text-stone-700 leading-relaxed">
           <section>
             <p className="text-stone-500">최종 업데이트: 2026년 5월 2일</p>
           </section>
@@ -75,7 +81,7 @@ export const TermsOfService: React.FC = () => {
 
           <section className="space-y-3">
             <h2 className="text-base font-bold text-stone-900">9. 문의</h2>
-            <p className="font-mono text-stone-600">jjakmi@gmail.com</p>
+            <p className="font-mono text-stone-600">{CONTACT_EMAIL}</p>
           </section>
         </div>
       </div>

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { User } from "firebase/auth";
+import { Link } from "react-router-dom";
 import { Modal } from "./Modal.js";
 
 interface UserSettingsProps {
@@ -128,6 +129,15 @@ export const UserSettings: React.FC<UserSettingsProps> = ({
                   <p className="text-xs text-stone-400">현재 기기에서 로그아웃합니다</p>
                 </div>
               </button>
+            </section>
+
+            {/* Legal */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-bold text-stone-400 uppercase tracking-widest">법적 정보</h3>
+              <div className="flex gap-4 text-xs text-stone-400 font-bold uppercase tracking-widest">
+                <Link to="/privacy" onClick={onClose} className="hover:text-stone-700 transition-colors">개인정보처리방침</Link>
+                <Link to="/terms" onClick={onClose} className="hover:text-stone-700 transition-colors">이용약관</Link>
+              </div>
             </section>
 
             {/* Danger zone */}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
 import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import ErrorBoundary from './components/ErrorBoundary.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
+    <BrowserRouter>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </BrowserRouter>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary

- Install `react-router-dom` and wrap app in `BrowserRouter`
- `/privacy` → 개인정보처리방침 (수집 항목, 이용 목적, 보유 기간, 제3자 서비스, 사용자 권리, 연락처)
- `/terms` → 이용약관 (이용 자격, 이용 규칙, AI 기능, 책임 한계, 준거법)
- 뒤로 가기 버튼으로 이전 페이지로 복귀
- 메인 앱 푸터에 Privacy / Terms 링크 추가
- UserSettings 패널 내 "법적 정보" 섹션에 링크 추가

## Test plan

- [ ] `/privacy` 직접 접근 시 페이지 렌더링 확인
- [ ] `/terms` 직접 접근 시 페이지 렌더링 확인
- [ ] 뒤로 가기 버튼 동작 확인
- [ ] 푸터 링크 → `/privacy`, `/terms` 이동 확인
- [ ] UserSettings 패널 링크 클릭 시 패널 닫힘 + 해당 페이지 이동 확인
- [ ] 기존 메인 앱 (`/`) 정상 동작 확인

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)